### PR TITLE
"Support" metadata version 2.4

### DIFF
--- a/src/whl2conda/api/converter.py
+++ b/src/whl2conda/api/converter.py
@@ -273,7 +273,7 @@ class Wheel2CondaConverter:
     """
 
     SUPPORTED_WHEEL_VERSIONS = ("1.0",)
-    SUPPORTED_METADATA_VERSIONS = ("1.0", "1.1", "1.2", "2.1", "2.2", "2.3")
+    SUPPORTED_METADATA_VERSIONS = ("1.0", "1.1", "1.2", "2.1", "2.2", "2.3", "2.4")
     MULTI_USE_METADATA_KEYS = {
         "Classifier",
         "Dynamic",


### PR DESCRIPTION
This is necessary for setuptools>=77, see https://github.com/pypa/setuptools/pull/4869 and in particular

https://github.com/pypa/setuptools/blob/8653b91b2b3bdf8a6b77a26d0aa4dd28ffda9bc5/setuptools/_vendor/wheel/cli/convert.py#L90

Fixes #151