### PR TITLE
Add automated release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,150 @@
+name: release
+
+# Automated release (#145): pushing a version tag (v*) builds the wheel,
+# sdist, and conda package, publishes the wheel and sdist to PyPI using
+# Trusted Publishing (OIDC), creates a GitHub release with notes from the
+# changelog and the conda package attached, and deploys the versioned
+# documentation to gh-pages with mike.
+#
+# workflow_dispatch runs only the build job, as a dry run.
+#
+# See RELEASING.md for the full release procedure.
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: build packages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pixi
+        uses: prefix-dev/setup-pixi@v0.9.0
+        with:
+          pixi-version: v0.48.2
+          cache: true
+
+      - name: Check tag matches VERSION file
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          version="$(tr -d '[:space:]' < src/whl2conda/VERSION)"
+          if [ "v$version" != "$GITHUB_REF_NAME" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME does not match VERSION file ($version)"
+            exit 1
+          fi
+
+      - name: Install package
+        run: pixi run dev-install
+
+      - name: Build wheel, sdist and conda package
+        run: pixi run build
+
+      - name: Check packages
+        run: pixi run check-upload
+
+      - name: Upload PyPI distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: pypi-dist
+          path: |
+            dist/*.whl
+            dist/*.tar.gz
+
+      - name: Upload conda package
+        uses: actions/upload-artifact@v4
+        with:
+          name: conda-pkg
+          path: dist/*.conda
+
+  publish-pypi:
+    name: publish to PyPI
+    needs: [build]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    # Uses Trusted Publishing (OIDC) — the publisher must be configured on
+    # PyPI for this repository, workflow release.yml, environment pypi.
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: pypi-dist
+          path: dist
+      - uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: create GitHub release
+    needs: [publish-pypi]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Extract changelog notes
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          awk -v ver="$version" '
+            $0 ~ "^## \\[" ver "\\]" { flag = 1; next }
+            /^## \[/ { flag = 0 }
+            flag
+          ' CHANGELOG.md > release-notes.md
+          if ! [ -s release-notes.md ]; then
+            echo "::warning::No changelog section found for $version"
+            echo "See [CHANGELOG.md](https://github.com/${GITHUB_REPOSITORY}/blob/main/CHANGELOG.md)" > release-notes.md
+          fi
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --title "whl2conda $GITHUB_REF_NAME" \
+            --notes-file release-notes.md \
+            dist/*
+
+  docs:
+    name: deploy versioned docs
+    needs: [publish-pypi]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # mike pushes to the gh-pages branch
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # mike needs the gh-pages branch history
+
+      - name: Setup pixi
+        uses: prefix-dev/setup-pixi@v0.9.0
+        with:
+          pixi-version: v0.48.2
+          cache: true
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Install package
+        run: pixi run dev-install
+
+      - name: Build documentation
+        run: pixi run doc
+
+      - name: Deploy documentation to gh-pages
+        run: |
+          pixi run doc-deploy
+          pixi run doc-push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
   in the wheel metadata and its PEP 503 normalized form, so patterns
   containing `_` or `.` work again. (#184)
 
+### Development
+
+* Automated release workflow: pushing a version tag publishes to PyPI
+  (trusted publishing), creates the GitHub release, and deploys the
+  versioned documentation (#145)
+
 ## [26.2.0] - 2026-2-22
 
 ### Features

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,6 +2,27 @@
 
 This document describes the steps to create a new release of whl2conda.
 
+Releases are automated (#145): pushing a `vYY.M.patch` tag triggers the
+[release workflow](.github/workflows/release.yml), which builds the wheel,
+sdist, and conda package, publishes the wheel and sdist to PyPI, creates a
+GitHub release with notes taken from the changelog and the conda package
+attached, and deploys the versioned documentation to GitHub Pages.
+
+## One-time setup: PyPI trusted publisher
+
+The workflow authenticates to PyPI with [Trusted
+Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC) — no API token
+secret is stored in the repository. This requires a one-time configuration in
+the [whl2conda project settings on PyPI](https://pypi.org/manage/project/whl2conda/settings/publishing/):
+
+- Owner: `zuzukin`, repository: `whl2conda`
+- Workflow name: `release.yml`
+- Environment name: `pypi`
+
+A matching `pypi` environment should also exist in the GitHub repository
+settings (Settings → Environments); it may optionally restrict deployments
+to `v*` tags.
+
 ## Versioning
 
 whl2conda uses calendar versioning (CalVer) in the format `YY.M.patch`:
@@ -56,90 +77,61 @@ pixi run typecheck
 
 Ensure all tests pass on the current branch. CI should also pass on all platforms.
 
-### 6. Build packages
-
-Clean any previous build artifacts and build fresh:
-
-```bash
-pixi run clean-build
-pixi run build
-```
-
-This builds both the wheel/sdist and the conda package.
-
-### 7. Verify packages
-
-Check that packages are well-formed:
-
-```bash
-pixi run check-upload
-```
-
-Optionally, test the conda package locally:
-
-```bash
-conda create -n test-whl2conda dist/*.conda
-conda activate test-whl2conda
-whl2conda --version
-whl2conda convert --help
-```
-
-### 8. Commit and tag
+### 6. Commit and merge to main
 
 ```bash
 git add src/whl2conda/VERSION CHANGELOG.md src/whl2conda/api/stdrename.json
 git commit -m "Release YY.M.patch"
-git tag vYY.M.patch
-```
-
-### 9. Push and verify CI
-
-```bash
 git push origin release/YY.M.patch
-git push origin vYY.M.patch
 ```
 
-Wait for CI to pass on the release branch.
+Create a PR from the release branch to `main`, wait for CI to pass, and merge it.
 
 ## Publish
 
-### 10. Upload to PyPI
+### 7. Push the release tag
+
+Tag the release commit on `main` and push the tag:
 
 ```bash
-pixi run upload
+git checkout main
+git pull
+git tag vYY.M.patch
+git push origin vYY.M.patch
 ```
 
-This runs `twine check` and then uploads the wheel and sdist to PyPI.
+This triggers the [release workflow](.github/workflows/release.yml), which:
 
-### 11. Create GitHub release
+1. Builds the wheel, sdist, and conda package, verifying that the tag
+   matches `src/whl2conda/VERSION`
+2. Publishes the wheel and sdist to PyPI
+3. Creates a GitHub release titled with the tag, using the matching
+   `CHANGELOG.md` section as notes, with the built packages attached
+4. Deploys the versioned documentation to gh-pages using mike
 
-Go to the [GitHub releases page](https://github.com/zuzukin/whl2conda/releases)
-and create a new release from the tag. Copy the relevant changelog entries into
-the release notes.
+Watch the workflow at the [actions page](https://github.com/zuzukin/whl2conda/actions)
+(or `gh run watch`), then verify:
 
-### 12. Deploy documentation
+- The new version appears on [PyPI](https://pypi.org/project/whl2conda/)
+- The [GitHub release](https://github.com/zuzukin/whl2conda/releases) looks right
+- The [documentation site](https://zuzukin.github.io/whl2conda/) shows the new version
 
-```bash
-pixi run doc-deploy
-pixi run doc-push
-```
-
-### 13. Merge to main
-
-Create a PR from the release branch to `main` and merge it.
+The build job can be exercised without releasing by running the workflow
+manually from the actions page (`workflow_dispatch`); publishing only happens
+on version tags.
 
 ## Post-release
 
-### 14. conda-forge update
+### 8. conda-forge update
 
 The [whl2conda-feedstock](https://github.com/conda-forge/whl2conda-feedstock)
 should automatically detect the new PyPI release and open a PR to update the
 conda-forge package. Review and merge that PR.
 
-### 15. Prepare for next development cycle
+### 9. Prepare for next development cycle
 
-After merging, update `src/whl2conda/VERSION` on `main` to the next expected
-version and add a new changelog section if not already present.
+Update `src/whl2conda/VERSION` on `main` to the next expected version and add
+a new changelog section if not already present.
 
 ## Pixi Tasks Reference
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -295,7 +295,7 @@ cmd = "rm -rf site doc/reference/cli/whl2conda*.md"
 description = "Remove generated documentation files"
 
 [tool.pixi.tasks.clean-build]
-cmd = "bash -c 'find . \\( -name \"*.whl\" -or -name \"*.conda\" -or -name \"*.tar.bz2\" \\) -exec rm {} \\; && find . \\( -name \"dist\" -or -name \"build\" -or -name \"*.egg-info\" \\) -exec rm -rf {} \\;'"
+cmd = "bash -c 'find . \\( -name .pixi -or -name .git \\) -prune -or \\( -name \"*.whl\" -or -name \"*.conda\" -or -name \"*.tar.bz2\" \\) -type f -exec rm {} \\; ; find . \\( -name .pixi -or -name .git \\) -prune -or \\( -name \"dist\" -or -name \"build\" -or -name \"*.egg-info\" \\) -prune -exec rm -rf {} \\;'"
 description = "Remove build artifacts and distribution files"
 
 [tool.pixi.tasks.clean]


### PR DESCRIPTION
Fixes #145

Pushing a `vYY.M.patch` tag now runs [release.yml](.github/workflows/release.yml), which:

1. **Builds** the wheel, sdist, and conda package with the existing pixi tasks, failing early if the tag does not match `src/whl2conda/VERSION`, and runs `twine check`.
2. **Publishes to PyPI** via [Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC, `environment: pypi`) — no API token secret.
3. **Creates the GitHub release**, titled from the tag, with notes extracted from the matching `CHANGELOG.md` section and the wheel/sdist/conda packages attached.
4. **Deploys versioned documentation** to gh-pages via the existing mike-based `doc-deploy` task.

`workflow_dispatch` runs only the build job as a dry run; publishing happens only on version tags. RELEASING.md is updated for the new procedure, including the one-time PyPI trusted-publisher setup.

Also fixes the `clean-build` pixi task, which was descending into `.pixi/` and deleting the `python-build` package out of the environment (breaking subsequent `pixi run build`).

Verified locally: workflow YAML parses; changelog note extraction produces the 26.2.1 section; `clean-build` → `build` → `check-upload` and `doc` all succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)