### PR TITLE
Fix `whl2conda diff` crash on packages without info/files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
 * The `--python` option now overrides the automatically generated python
   version pin for binary (`--allow-impure`) conversions (#183)
 
+### Bug fixes
+
+* `whl2conda diff` no longer fails on packages that do not contain an
+  `info/files` entry, e.g. packages built by rattler-build (#192)
+
 ## [26.2.1] - 2026-7-9
 
 ### Bug fixes

--- a/src/whl2conda/cli/diff.py
+++ b/src/whl2conda/cli/diff.py
@@ -124,19 +124,20 @@ def diff_main(
         pkg1_dir = tmpdir / "pkg1"
         pkg2_dir = tmpdir / "pkg2"
 
-        _extract_packge(parsed.package1, pkg1_dir)
-        _extract_packge(parsed.package2, pkg2_dir)
+        _extract_package(parsed.package1, pkg1_dir)
+        _extract_package(parsed.package2, pkg2_dir)
 
         subprocess.run(
             [diff_tool, str(pkg1_dir), str(pkg2_dir), *diff_args], check=False
         )
 
 
-def _extract_packge(package: Path, dest_dir: Path) -> None:
+def _extract_package(package: Path, dest_dir: Path) -> None:
     dest_dir.mkdir(parents=True, exist_ok=True)
     cphapi.extract(str(package), dest_dir)
 
-    # normalize contents
+    # normalize contents - any of these may be missing, e.g. packages
+    # built by rattler-build do not contain info/files
     info_dir = dest_dir / "info"
     _normalize_json(info_dir / "about.json")
     _normalize_json(info_dir / "link.json")
@@ -155,17 +156,23 @@ def _extract_packge(package: Path, dest_dir: Path) -> None:
 
 
 def _normalize_json(file: Path) -> None:
+    if not file.is_file():
+        return
     jobj = json.loads(file.read_text("utf8"))
     file.write_text(json.dumps(jobj, indent=2, sort_keys=True))
 
 
 def _normalize_index(file: Path) -> None:
+    if not file.is_file():
+        return
     jobj = json.loads(file.read_text("utf8"))
     jobj["depends"] = sorted(jobj["depends"])
     file.write_text(json.dumps(jobj, indent=2, sort_keys=True))
 
 
 def _normalize_paths(file: Path) -> None:
+    if not file.is_file():
+        return
     jobj = json.loads(file.read_text("utf8"))
     paths = jobj["paths"]
     jobj["paths"] = sorted(paths, key=lambda entry: entry["_path"])
@@ -177,6 +184,8 @@ def _normalize_paths(file: Path) -> None:
 
 
 def _sort_lines(file: Path) -> None:
+    if not file.is_file():
+        return
     with open(file) as f:
         lines = f.readlines()
     with open(file, "w") as f:

--- a/test/cli/test_diff.py
+++ b/test/cli/test_diff.py
@@ -22,6 +22,7 @@ import argparse
 import re
 from pathlib import Path
 
+import conda_package_handling.api as cphapi
 import pytest
 
 from whl2conda.cli import main
@@ -120,3 +121,38 @@ def test_diff(
     assert not list(tmp_path.glob("**/*"))
 
     # TODO test file normalization has happened
+
+
+def test_diff_missing_info_files(
+    tmp_path: Path,
+    simple_conda_package: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    diff tolerates packages without an info/files entry (#192)
+
+    Packages built by rattler-build only contain info/paths.json.
+    """
+    # repackage the test package without its info/files
+    extract_dir = tmp_path / "extracted"
+    cphapi.extract(str(simple_conda_package), str(extract_dir))
+    (extract_dir / "info" / "files").unlink()
+    cphapi.create(
+        str(extract_dir), None, simple_conda_package.name, out_folder=str(tmp_path)
+    )
+    stripped_package = tmp_path / simple_conda_package.name
+    assert stripped_package.is_file()
+
+    diff_ran = False
+
+    def _fake_diff(cmd: list[str], **_kwargs) -> None:
+        nonlocal diff_ran
+        diff_ran = True
+        for d in cmd[1:3]:
+            assert (Path(d) / "info" / "index.json").is_file()
+
+    monkeypatch.setattr("subprocess.run", _fake_diff)
+    monkeypatch.chdir(tmp_path)
+
+    main(["diff", str(simple_conda_package), str(stripped_package), "-T", "diff"])
+    assert diff_ran

--- a/test/cli/test_diff.py
+++ b/test/cli/test_diff.py
@@ -129,14 +129,16 @@ def test_diff_missing_info_files(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
-    diff tolerates packages without an info/files entry (#192)
+    diff tolerates packages with missing info files (#192)
 
-    Packages built by rattler-build only contain info/paths.json.
+    In particular, packages built by rattler-build do not contain
+    an info/files entry.
     """
-    # repackage the test package without its info/files
+    # repackage the test package without most of its info files
     extract_dir = tmp_path / "extracted"
     cphapi.extract(str(simple_conda_package), str(extract_dir))
-    (extract_dir / "info" / "files").unlink()
+    for name in ["files", "about.json", "link.json", "index.json", "paths.json"]:
+        (extract_dir / "info" / name).unlink()
     cphapi.create(
         str(extract_dir), None, simple_conda_package.name, out_folder=str(tmp_path)
     )
@@ -149,7 +151,7 @@ def test_diff_missing_info_files(
         nonlocal diff_ran
         diff_ran = True
         for d in cmd[1:3]:
-            assert (Path(d) / "info" / "index.json").is_file()
+            assert (Path(d) / "info").is_dir()
 
     monkeypatch.setattr("subprocess.run", _fake_diff)
     monkeypatch.chdir(tmp_path)


### PR DESCRIPTION
Packages built by rattler-build do not contain a legacy `info/files` entry (only `info/paths.json`), so `whl2conda diff` always crashed with `FileNotFoundError` when comparing against one — one of the primary use cases of the command.

- All the info-file normalizers in `cli/diff.py` now skip files that are not present in the package.
- Fixed the `_extract_packge` → `_extract_package` typo in passing.
- Added a regression test that repackages the simple test package without its `info/files` and diffs it.

Fixes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)