### PR TITLE
Write index.json timestamp in milliseconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@
 * The `--python` option now overrides the automatically generated python
   version pin for binary (`--allow-impure`) conversions (#183)
 
+### Bug fixes
+
+* The `timestamp` in the package's `index.json` is now written in
+  milliseconds since the epoch, matching conda-build and rattler-build.
+  It was previously written in seconds and was also incorrectly shifted
+  by the local timezone offset. (#193)
+
 ## [26.2.1] - 2026-7-9
 
 ### Bug fixes

--- a/src/whl2conda/api/converter.py
+++ b/src/whl2conda/api/converter.py
@@ -803,7 +803,7 @@ class Wheel2CondaConverter:
             "name": wheel_md.package_name,
             "platform": conda_target.platform,
             "subdir": conda_target.subdir,
-            "timestamp": int(time.time() + time.timezone),  # UTC timestamp
+            "timestamp": int(time.time() * 1000),  # milliseconds since epoch
             "version": wheel_md.version,
         }
         if conda_target.uses_noarch_python:

--- a/test/api/validator.py
+++ b/test/api/validator.py
@@ -24,6 +24,7 @@ import logging
 import os.path
 import re
 import shutil
+import time
 from collections.abc import Generator, Sequence
 from pathlib import Path
 from typing import Any
@@ -320,6 +321,10 @@ class PackageValidator:
         else:
             assert name == re.sub(r"[-_.]+", "-", wheel_md["name"]).lower()
         assert version == wheel_md["version"]
+
+        # timestamp is milliseconds since the epoch (#193)
+        now_ms = time.time() * 1000
+        assert now_ms - 3_600_000 < index["timestamp"] <= now_ms
 
         if self._is_binary:
             assert index["arch"] is not None


### PR DESCRIPTION
The `timestamp` field in `info/index.json` was written as `int(time.time() + time.timezone)`:

- seconds instead of the milliseconds-since-epoch convention used by conda-build and rattler-build (conda tooling only interprets a seconds value heuristically), and
- skewed by the local UTC offset, since `time.time()` is already a UTC epoch value.

Now written as `int(time.time() * 1000)`. The package validator used by the converter tests now asserts the timestamp is in a millisecond-scale window around the current time.

Fixes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)