### PR TITLE
Add `--for-conda-forge` option for CEP-20 abi3 python pins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
   noarch python machinery (#183)
 * The `--python` option now overrides the automatically generated python
   version pin for binary (`--allow-impure`) conversions (#183)
+* New `--for-conda-forge` option (synonym: `--for-cpython`) adds the CEP-20
+  python pins used by conda-forge (`cpython` and `_python_abi3_support`)
+  when converting stable ABI (abi3) wheels (#194)
 
 ## [26.2.1] - 2026-7-9
 

--- a/doc/guide/binary-conversion.md
+++ b/doc/guide/binary-conversion.md
@@ -53,6 +53,24 @@ platform-specific conda package that installs on any compatible Python:
     since conda 4.3 (2017) and works regardless of the package's platform
     subdir, as codified by CEP-20.
 
+### conda-forge style pins
+
+By default the python dependency is a plain floor (e.g. `python >=3.12`),
+which is solvable on any channel. conda-forge instead pins its abi3 packages
+with `cpython >=3.12` (which excludes PyPy, whose C API layer does not
+support the stable ABI) and `_python_abi3_support 1.*` (which additionally
+excludes free-threaded python builds). Pass `--for-conda-forge` (or its
+synonym `--for-cpython`) to add these pins:
+
+```bash
+whl2conda convert mypackage-1.0-cp312-abi3-macosx_11_0_arm64.whl \
+    --allow-impure --for-conda-forge
+```
+
+Since the `cpython` and `_python_abi3_support` packages only exist on the
+conda-forge channel, do not use this option for packages targeting channels
+without them (e.g. Anaconda's `defaults`).
+
 ## Downloading binary wheels
 
 You can download and convert binary wheels from PyPI in a single step using

--- a/src/whl2conda/api/converter.py
+++ b/src/whl2conda/api/converter.py
@@ -547,6 +547,7 @@ class Wheel2CondaConverter:
     interactive: bool = False
     build_number: int | None = None
     allow_impure: bool = False
+    for_conda_forge: bool = False
 
     wheel_md: MetadataFromWheel | None = None
     conda_target: CondaTargetInfo | None = None
@@ -991,23 +992,28 @@ class Wheel2CondaConverter:
 
         For abi3 (stable ABI) wheels, only a minimum python version derived
         from the wheel's Python tag is required, since the package works on
-        all later versions.
+        all later versions. If `for_conda_forge` is set, the CEP-20 pins
+        used by conda-forge (`cpython` and `_python_abi3_support`) are also
+        added for abi3 wheels.
 
         An explicit python version setting on the converter overrides the
         automatically derived pin.
         """
         result = list(conda_dependencies)
+        abi3_python_spec = ""
         if self.python_version:
             # User override was already applied in _compute_conda_dependencies
             self._debug(
                 "Binary python pin overridden by user: python %s",
                 self.python_version,
             )
+            abi3_python_spec = self.python_version
         elif conda_target.is_abi3:
             # Stable ABI: works on all versions >= the build version, so
             # only add a floor. Keep any Requires-Python constraint, which
             # may be tighter.
-            floor = f"python >={conda_target.python_version}"
+            abi3_python_spec = f">={conda_target.python_version}"
+            floor = f"python {abi3_python_spec}"
             if floor not in result:
                 result.append(floor)
             self._debug("Binary abi3 python floor: %s", floor)
@@ -1018,6 +1024,18 @@ class Wheel2CondaConverter:
             self._debug(
                 "Binary python pin: %s",
                 ", ".join(python_pin),
+            )
+
+        if conda_target.is_abi3 and self.for_conda_forge:
+            # CEP-20 pins used by conda-forge: `cpython` excludes PyPy, and
+            # `_python_abi3_support` additionally excludes free-threaded
+            # builds, neither of which support the stable ABI. These
+            # packages only exist on the conda-forge channel.
+            cpython_pin = f"cpython {abi3_python_spec}".rstrip()
+            result.append(cpython_pin)
+            result.append("_python_abi3_support 1.*")
+            self._debug(
+                "conda-forge abi3 pins: %s, _python_abi3_support 1.*", cpython_pin
             )
 
         if os_constraint := _os_constraint_from_platform_tag(platform_tag):

--- a/src/whl2conda/cli/convert.py
+++ b/src/whl2conda/cli/convert.py
@@ -63,6 +63,7 @@ class ConvertArgs:
     dropped_deps: Sequence[str]
     dry_run: bool
     extra_deps: list[str]
+    for_conda_forge: bool
     from_index: tuple[str, str] | None
     from_pypi: str | None
     ignore_pyproject: bool
@@ -293,6 +294,20 @@ def _create_argparser(prog: str | None = None) -> argparse.ArgumentParser:
             Generates tight Python version pins and OS constraints from wheel
             tags. Stable ABI (abi3) wheels are only pinned to a minimum python
             version. Use --python to override the generated python dependency.
+        """),
+    )
+
+    experimental_opts.add_argument(
+        "--for-conda-forge",
+        "--for-cpython",
+        dest="for_conda_forge",
+        action="store_true",
+        help=dedent("""
+            When converting a stable ABI (abi3) wheel, also add the CEP-20
+            python pins used by conda-forge: 'cpython' (excludes PyPy) and
+            '_python_abi3_support' (excludes free-threaded builds). These
+            packages only exist on the conda-forge channel, so do not use
+            this option for packages targeting channels without them.
         """),
     )
 
@@ -597,6 +612,7 @@ def convert_main(args: Sequence[str] | None = None, prog: str | None = None):
         converter.interactive = interactive
         converter.build_number = parsed.build_number
         converter.allow_impure = parsed.allow_impure or bool(download_platform)
+        converter.for_conda_forge = parsed.for_conda_forge
         if parsed.allow_metadata_version:
             converter.SUPPORTED_METADATA_VERSIONS = (
                 *converter.SUPPORTED_METADATA_VERSIONS,

--- a/test/api/test_converter.py
+++ b/test/api/test_converter.py
@@ -1136,6 +1136,53 @@ def test_add_binary_dependencies_abi3() -> None:
     assert "python >=3.12" in result
 
 
+def test_add_binary_dependencies_abi3_conda_forge() -> None:
+    """Test conda-forge CEP-20 pins for abi3 wheels (#194)."""
+    converter = Wheel2CondaConverter(Path("fake.whl"), Path("."))
+    converter.logger = logging.getLogger(__name__)
+    converter.for_conda_forge = True
+
+    abi3_target = CondaTargetInfo(
+        subdir="osx-arm64",
+        arch="arm64",
+        platform="osx",
+        build_string="py312_abi3_0",
+        is_noarch=False,
+        site_packages_prefix="site-packages",
+        python_version="3.12",
+        is_abi3=True,
+    )
+
+    result = converter._add_binary_dependencies([], abi3_target, "macosx_11_0_arm64")
+    assert "python >=3.12" in result
+    assert "cpython >=3.12" in result
+    assert "_python_abi3_support 1.*" in result
+
+    # cpython pin mirrors an explicit python version override
+    converter.python_version = ">=3.13"
+    result = converter._add_binary_dependencies(
+        ["python >=3.13"], abi3_target, "macosx_11_0_arm64"
+    )
+    assert "cpython >=3.13" in result
+    assert "_python_abi3_support 1.*" in result
+
+    # no effect on non-abi3 binary wheels, whose python_abi pin already
+    # restricts the package to cpython
+    converter.python_version = ""
+    non_abi3_target = CondaTargetInfo(
+        subdir="linux-64",
+        arch="x86_64",
+        platform="linux",
+        build_string="py312_0",
+        is_noarch=False,
+        site_packages_prefix="lib/python3.12/site-packages",
+        python_version="3.12",
+    )
+    result = converter._add_binary_dependencies([], non_abi3_target, "linux_x86_64")
+    assert not any(d.startswith("cpython") for d in result)
+    assert not any(d.startswith("_python_abi3_support") for d in result)
+
+
 def test_add_binary_dependencies_python_override() -> None:
     """Test that an explicit python version overrides binary pins (#183)."""
     converter = Wheel2CondaConverter(Path("fake.whl"), Path("."))

--- a/test/cli/test_convert.py
+++ b/test/cli/test_convert.py
@@ -86,6 +86,7 @@ class CliTestCase:
     expected_download_index: str = ""
     expected_dry_run: bool = False
     expected_extra_dependencies: Sequence[str] = ()
+    expected_for_conda_forge: bool = False
     expected_interactive: bool = True
     expected_keep_pip: bool = False
     expected_out_dir: str = ""
@@ -129,6 +130,7 @@ class CliTestCase:
         expected_extra_dependencies: Sequence[str] = (),
         expected_download_index: str = "",
         expected_download_spec: str = "",
+        expected_for_conda_forge: bool = False,
         expected_interactive: bool = True,
         expected_keep_pip: bool = False,
         expected_out_dir: str = "",
@@ -156,6 +158,7 @@ class CliTestCase:
         self.expected_download_index = expected_download_index
         self.expected_download_spec = expected_download_spec
         self.expected_extra_dependencies = list(expected_extra_dependencies)
+        self.expected_for_conda_forge = expected_for_conda_forge
         self.expected_interactive = expected_interactive
         self.expected_keep_pip = expected_keep_pip
         self.expected_out_dir = expected_out_dir
@@ -335,6 +338,7 @@ class CliTestCase:
         assert converter.out_format is self.expected_out_fmt
         assert converter.overwrite is self.expected_overwrite
         assert converter.keep_pip_dependencies is self.expected_keep_pip
+        assert converter.for_conda_forge is self.expected_for_conda_forge
         assert converter.extra_dependencies == list(self.expected_extra_dependencies)
         assert converter.dependency_rename == list(self.expected_dependency_renames)
         assert converter.python_version == self.expected_python_version
@@ -395,6 +399,7 @@ class CliTestCaseFactory:
         expected_overwrite: bool = False,
         expected_keep_pip: bool = False,
         expected_extra_dependencies: Sequence[str] = (),
+        expected_for_conda_forge: bool = False,
         expected_interactive: bool = True,
         expected_project_root: str = "",
         expected_python_version: str = "",
@@ -422,6 +427,7 @@ class CliTestCaseFactory:
             expected_overwrite=expected_overwrite,
             expected_keep_pip=expected_keep_pip,
             expected_extra_dependencies=expected_extra_dependencies,
+            expected_for_conda_forge=expected_for_conda_forge,
             expected_interactive=expected_interactive,
             expected_project_root=expected_project_root,
             expected_python_version=expected_python_version,
@@ -956,6 +962,17 @@ def test_python_override(
     test_case(
         [str(simple_wheel), "--python", ">=3.10"], expected_python_version=">=3.10"
     ).run()
+
+
+def test_for_conda_forge(
+    test_case: CliTestCaseFactory,
+    simple_wheel: Path,
+) -> None:
+    """Test --for-conda-forge option and its --for-cpython synonym (#194)"""
+    test_case(
+        [str(simple_wheel), "--for-conda-forge"], expected_for_conda_forge=True
+    ).run()
+    test_case([str(simple_wheel), "--for-cpython"], expected_for_conda_forge=True).run()
 
 
 def test_allow_metadata_version(


### PR DESCRIPTION
Adds an opt-in `--for-conda-forge` flag (synonym: `--for-cpython`) to `whl2conda convert`. When converting a stable ABI (abi3) wheel, it emits the CEP-20 python pins used by conda-forge in addition to the default `python >=X.Y` floor:

- `cpython >=X.Y` — excludes PyPy, whose C API layer does not support the stable ABI
- `_python_abi3_support 1.*` — the conda-forge marker package, which additionally excludes free-threaded python builds via its `python-gil` dependency

The default behavior is unchanged, since these packages only exist on the conda-forge channel (verified absent from Anaconda `defaults`), and a hard dependency on them would make generated packages unsolvable elsewhere.

Details:
- An explicit `--python` override is mirrored into the `cpython` pin (e.g. `--python '>=3.13'` → `cpython >=3.13`).
- The flag has no effect on non-abi3 binary conversions, whose `python_abi X.Y.* *_cpXY` pin already restricts the package to CPython, nor on pure-python conversions.
- Documented in the binary-conversion guide; CLI reference regenerates from help text.

Converting the antlrope 1.0.0 abi3 wheel with the flag now yields the same dependency set as the equivalent conda-forge-style rattler-build package:

```
['antlr4-python3-runtime >=4.13', 'python >=3.12', 'cpython >=3.12', '_python_abi3_support 1.*', '__osx >=11.0']
```

A possible follow-up is a `[tool.whl2conda]` pyproject.toml setting for this, since projects will typically want it persistently.

Fixes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)