### PR TITLE
Remove obsolete classic-solver workaround from `whl2conda install`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@
   python pins used by conda-forge (`cpython` and `_python_abi3_support`)
   when converting stable ABI (abi3) wheels (#194)
 
+### Changes
+
+* `whl2conda install` no longer checks the conda-libmamba-solver version
+  or switches target environments to the classic solver. That workaround
+  was only needed for conda-libmamba-solver older than 24.1.0, which fixed
+  the underlying file-install issue
+  ([conda-libmamba-solver#418](https://github.com/conda/conda-libmamba-solver/issues/418)).
+  This also removes a crash when conda-libmamba-solver was not installed
+  in the base environment.
+
 ### Development
 
 * Documentation is now generated with [Zensical](https://zensical.org)

--- a/src/whl2conda/cli/install.py
+++ b/src/whl2conda/cli/install.py
@@ -287,40 +287,6 @@ def conda_env_install(parsed: InstallArgs, dependencies: list[str]):
             else:
                 subprocess.check_call(install_pkg_cmd)
 
-        check_libmamba_cmd = [
-            "conda",
-            "list",
-            "-n",
-            "base",
-            "conda-libmamba-solver",
-            "--json",
-        ]
-        if parsed.dry_run:
-            print("running ", check_libmamba_cmd)
-        else:
-            jsonstr = subprocess.check_output(check_libmamba_cmd, encoding="utf-8")
-            jobj = json.loads(jsonstr)
-            version_str = jobj and jobj[0].get("version")
-            version = tuple(int(s) for s in version_str.split("."))
-            if version < (24, 1, 0):
-                # Workaround for https://github.com/conda/conda/issues/13479
-                # If a package is installed directly from file, then set solver to classic
-                set_solver_cmd = [
-                    "conda",
-                    "run",
-                    *env_opts,
-                    "conda",
-                    "config",
-                    "--env",
-                    "--set",
-                    "solver",
-                    "classic",
-                ]
-                if parsed.dry_run:
-                    print("Running ", set_solver_cmd)
-                else:
-                    subprocess.check_call(set_solver_cmd)
-
 
 conda_depend_re = re.compile(r"\s*(?P<name>[\w\d.-]+)\s*(?P<version>.*)")
 

--- a/test/cli/test_install.py
+++ b/test/cli/test_install.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 import re
 from collections.abc import Sequence
 from pathlib import Path
-from textwrap import dedent
 from typing import Any
 
 import pytest
@@ -218,26 +217,7 @@ def test_env_install_whitebox(
     prefix = tmp_path.joinpath("prefix")
 
     call_args: list[list[str]] = []
-    fake_call_results: list[Any] = [
-        None,
-        None,
-        dedent(
-            """
-            [
-              {
-                "base_url": "https://conda.anaconda.org/conda-forge",
-                "build_number": 0,
-                "build_string": "pyhd8ed1ab_0",
-                "channel": "conda-forge",
-                "dist_name": "conda-libmamba-solver-24.1.0-pyhd8ed1ab_0",
-                "name": "conda-libmamba-solver",
-                "platform": "noarch",
-                "version": "24.1.0"
-              }
-            ]
-            """
-        ),
-    ]
+    fake_call_results: list[Any] = [None, None]
 
     def fake_call(cmd: Sequence[str], encoding=None) -> Any:
         if encoding:
@@ -256,7 +236,7 @@ def test_env_install_whitebox(
 
     main([*cmd_start, "--prefix", str(prefix), "--yes"])
 
-    assert len(call_args) == 3
+    assert len(call_args) == 2
     call1 = call_args[0]
     assert call1[0] == "conda"
     assert call1[1] == "install"
@@ -274,7 +254,7 @@ def test_env_install_whitebox(
     call_args.clear()
 
     main([*cmd_start, "--name", "test-env", "--create", "--mamba"])
-    assert len(call_args) == 3
+    assert len(call_args) == 2
     call1 = call_args[0]
     call2 = call_args[1]
     assert call1[:2] == ["mamba", "create"]
@@ -304,33 +284,6 @@ def test_env_install_whitebox(
 
     out, err = capsys.readouterr()
     assert "Running" in out
-
-    # Test for presence of conda solver workaround for conda-libmamba-solver < 24.1
-    call_args.clear()
-    fake_call_results[2] = dedent(
-        """
-        [
-          {
-            "base_url": "https://conda.anaconda.org/conda-forge",
-            "build_number": 0,
-            "build_string": "pyhd8ed1ab_0",
-            "channel": "conda-forge",
-            "dist_name": "conda-libmamba-solver-23.12.0-pyhd8ed1ab_0",
-            "name": "conda-libmamba-solver",
-            "platform": "noarch",
-            "version": "23.12.0"
-          }
-        ]
-        """
-    )
-
-    main([*cmd_start, "--name", "test-env", "--create", "--mamba"])
-    assert len(call_args) == 4
-    call4 = call_args[3]
-    assert call4[:4] == ["conda", "run", "--name", "test-env"]
-    assert call4[4:6] == ["conda", "config"]
-    assert "--set solver classic" in " ".join(call4)
-    assert "--env" in call4
 
 
 def test_prune_dependencies() -> None:


### PR DESCRIPTION
> [!NOTE]
> Stacked on #198 — merge that first and this will retarget.

The workaround for the libmamba file-install bug ([conda-libmamba-solver#418](https://github.com/conda/conda-libmamba-solver/issues/418), formerly conda/conda#13479) is obsolete: the issue was fixed in conda-libmamba-solver **24.1.0** (January 2024).

The code was already version-gated so it never fired on modern conda, but it still:

- ran a `conda list -n base conda-libmamba-solver --json` subprocess on **every** package-file install just to make that determination, and
- crashed with an `AttributeError` if `conda-libmamba-solver` was not installed in the base environment at all (empty `conda list` result → `[].split(".")`).

This removes the whole version-check + set-solver block and its test coverage. The stale doc note describing the workaround was already removed on the base branch (it misdescribed current behavior, since the version gate meant no modern environment was ever switched to the classic solver).

Environments running a pre-24.1 solver no longer get the automatic classic-solver fallback — an acceptable floor two and a half years after the fix shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)