### PR TITLE
Select best platform tag for multi-platform wheels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
   recipe-built packages. The `-T`/`--diff-tool` option is now optional and
   selects the previous raw diff behavior. The analysis engine is also
   available programmatically as `whl2conda.api.compare`.
+* New `--platform-tag` option selects the wheel platform tag to convert
+  for when converting a multi-platform ("fat") binary wheel (#201)
 
 ### Changes
 

--- a/doc/guide/binary-conversion.md
+++ b/doc/guide/binary-conversion.md
@@ -188,11 +188,23 @@ not automatically inherit correct library dependencies. You may need to manually
 specify additional dependencies using the `-A`/`--add-dependency` flag 
 during conversion.
 
-### `universal2` macOS wheels
+### Multi-platform (fat) macOS wheels
 
-macOS `universal2` wheels (containing both x86_64 and arm64 code) are mapped
-to `osx-arm64` only. There is currently no way to produce separate packages
-for both architectures from a single universal2 wheel.
+macOS wheels may support several platforms at once: `universal2` wheels
+contain both x86_64 and arm64 code, and some wheels are tagged for
+`x86_64`, `arm64`, *and* `universal2` simultaneously. Conversion produces
+a single conda package for one platform: the platform matching the
+current system is preferred; otherwise a `universal2` wheel is converted
+for `osx-arm64`. Use the `--platform-tag` option to select the target
+platform explicitly:
+
+```bash
+whl2conda convert orjson-3.11.9-*.whl --allow-impure \
+    --platform-tag macosx_10_15_x86_64
+```
+
+There is currently no way to produce packages for several architectures
+in a single conversion.
 
 ### No pre-compiled `.pyc` files
 

--- a/src/whl2conda/api/converter.py
+++ b/src/whl2conda/api/converter.py
@@ -42,6 +42,7 @@ from conda_package_handling.api import create as create_conda_pkg
 
 # this project
 from ..__about__ import __version__
+from ..impl.conda_forge import native_conda_subdir
 from ..impl.prompt import bool_input
 from ..impl.pyproject import CondaPackageFormat
 from ..impl.wheel import unpack_wheel
@@ -548,6 +549,8 @@ class Wheel2CondaConverter:
     build_number: int | None = None
     allow_impure: bool = False
     for_conda_forge: bool = False
+    platform_tag: str = ""
+    """Wheel platform tag to convert for, when the wheel supports several."""
 
     wheel_md: MetadataFromWheel | None = None
     conda_target: CondaTargetInfo | None = None
@@ -1229,16 +1232,16 @@ class Wheel2CondaConverter:
             )
 
         # Pick the best py3-compatible tag
-        wheel_tag = ""
-        for tag in all_tags:
-            parts = tag.lower().split("-")
-            if parts[0].startswith("py3") or parts[0].startswith("cp3"):
-                wheel_tag = tag
-                break
-        if not wheel_tag:
+        py3_tags = [
+            tag
+            for tag in all_tags
+            if tag.lower().partition("-")[0].startswith(("py3", "cp3"))
+        ]
+        if not py3_tags:
             raise Wheel2CondaError(
                 f"Wheel {self.wheel_path} has no Python 3 compatible tag"
             )
+        wheel_tag = self._select_wheel_tag(py3_tags)
 
         if not self.allow_impure:
             if not is_pure_lib:
@@ -1256,6 +1259,84 @@ class Wheel2CondaConverter:
 
         python_tag, abi_tag, platform_tag = wheel_tags
         return is_pure_lib, wheel_build_number, python_tag, abi_tag, platform_tag
+
+    def _select_wheel_tag(self, tags: list[str]) -> str:
+        """Select the wheel tag to convert for.
+
+        Multi-platform ("fat") wheels carry one tag per supported
+        platform. If the `platform_tag` attribute is set, the matching
+        tag is used. Otherwise, the tag matching the current platform
+        is preferred, then a `universal2` tag (which is converted for
+        osx-arm64), and otherwise the wheel's first tag.
+
+        Args:
+            tags: the wheel's python-3 compatible tags, in wheel order
+
+        Returns:
+            The selected tag.
+
+        Raises:
+            Wheel2CondaError: if the `platform_tag` attribute does not
+                match any of the wheel's tags.
+        """
+
+        def tag_platform(tag: str) -> str:
+            return tag.lower().rpartition("-")[2]
+
+        if override := self.platform_tag.lower():
+            for tag in tags:
+                if tag_platform(tag) == override:
+                    return tag
+            platforms = sorted({tag_platform(tag) for tag in tags})
+            raise Wheel2CondaError(
+                f"Wheel {self.wheel_path} has no platform tag"
+                f" '{self.platform_tag}' - available: {', '.join(platforms)}"
+            )
+
+        if len(tags) == 1:
+            return tags[0]
+
+        def prefer_arch_specific(group: list[str]) -> str:
+            # a universal2 tag pairs with an arch-specific tag for the
+            # same subdir, whose __osx version floor is more accurate
+            for tag in group:
+                if not tag_platform(tag).endswith("universal2"):
+                    return tag
+            return group[0]
+
+        # group the tags by their conda subdir, keeping unsupported
+        # platform tags in their own groups
+        subdirs: dict[str, list[str]] = {}
+        for tag in tags:
+            try:
+                subdir, _arch, _platform = _parse_platform_tag(tag_platform(tag))
+            except Wheel2CondaError:
+                subdir = tag_platform(tag)
+            subdirs.setdefault(subdir, []).append(tag)
+
+        if len(subdirs) == 1:
+            return prefer_arch_specific(tags)
+
+        # A fat wheel spanning multiple conda subdirs: prefer the
+        # current platform, then a universal2 tag (osx-arm64).
+        chosen = ""
+        native = native_conda_subdir()
+        if native in subdirs:
+            chosen = native
+        else:
+            for subdir, group in subdirs.items():
+                if any(tag_platform(tag).endswith("universal2") for tag in group):
+                    chosen = subdir
+                    break
+        if not chosen:
+            chosen = next(iter(subdirs))
+        self._warn(
+            "Wheel supports multiple platforms (%s); converting for %s. "
+            "Use --platform-tag to override.",
+            ", ".join(sorted(subdirs)),
+            chosen,
+        )
+        return prefer_arch_specific(subdirs[chosen])
 
     def _parse_dist_metadata(
         self, wheel_info_dir: Path

--- a/src/whl2conda/cli/convert.py
+++ b/src/whl2conda/cli/convert.py
@@ -73,6 +73,7 @@ class ConvertArgs:
     out_dir: Path | None
     out_format: str
     overwrite: bool
+    platform_tag: str
     project_root: Path | None
     python: str
     quiet: int
@@ -308,6 +309,18 @@ def _create_argparser(prog: str | None = None) -> argparse.ArgumentParser:
             '_python_abi3_support' (excludes free-threaded builds). These
             packages only exist on the conda-forge channel, so do not use
             this option for packages targeting channels without them.
+        """),
+    )
+
+    experimental_opts.add_argument(
+        "--platform-tag",
+        metavar="<tag>",
+        default="",
+        help=dedent("""
+            Wheel platform tag to convert for, when converting a
+            multi-platform ("fat") binary wheel that supports several
+            (e.g. 'macosx_10_15_x86_64'). By default, the platform
+            matching the current system is preferred.
         """),
     )
 
@@ -613,6 +626,7 @@ def convert_main(args: Sequence[str] | None = None, prog: str | None = None):
         converter.build_number = parsed.build_number
         converter.allow_impure = parsed.allow_impure or bool(download_platform)
         converter.for_conda_forge = parsed.for_conda_forge
+        converter.platform_tag = parsed.platform_tag
         if parsed.allow_metadata_version:
             converter.SUPPORTED_METADATA_VERSIONS = (
                 *converter.SUPPORTED_METADATA_VERSIONS,

--- a/test/api/compare_support.py
+++ b/test/api/compare_support.py
@@ -105,12 +105,7 @@ COMPARISON_PACKAGES: tuple[ComparisonPackage, ...] = (
         notes="the wheel statically links OpenSSL",
     ),
     ComparisonPackage("bcrypt", "abi3"),
-    ComparisonPackage(
-        "orjson",
-        "rust",
-        xfail_reason="compound macosx platform tag maps to wrong subdir"
-        " (https://github.com/zuzukin/whl2conda/issues/201)",
-    ),
+    ComparisonPackage("orjson", "rust"),
     ComparisonPackage("rpds-py", "rust"),
     ComparisonPackage(
         "lxml",

--- a/test/api/test_converter.py
+++ b/test/api/test_converter.py
@@ -1310,7 +1310,39 @@ def test_select_wheel_tag(
             ])
             == "cp313-cp313-manylinux_2_17_x86_64"
         )
+        # a group with only universal2 tags falls back to the first
+        assert (
+            converter._select_wheel_tag([
+                "cp39-abi3-macosx_10_15_universal2",
+                "cp310-abi3-macosx_11_0_universal2",
+            ])
+            == "cp39-abi3-macosx_10_15_universal2"
+        )
     assert not caplog.text
+
+    # unsupported platform tags group separately; supported host tag wins
+    monkeypatch.setattr(
+        "whl2conda.api.converter.native_conda_subdir", lambda: "osx-arm64"
+    )
+    assert (
+        converter._select_wheel_tag([
+            "cp313-cp313-freebsd_14_x86_64",
+            "cp313-cp313-macosx_11_0_arm64",
+        ])
+        == "cp313-cp313-macosx_11_0_arm64"
+    )
+
+    # no host match and no universal2 component: first tag wins
+    monkeypatch.setattr(
+        "whl2conda.api.converter.native_conda_subdir", lambda: "linux-64"
+    )
+    assert (
+        converter._select_wheel_tag([
+            "cp313-cp313-macosx_10_15_x86_64",
+            "cp313-cp313-macosx_11_0_arm64",
+        ])
+        == "cp313-cp313-macosx_10_15_x86_64"
+    )
 
 
 def test_select_wheel_tag_override(

--- a/test/api/test_converter.py
+++ b/test/api/test_converter.py
@@ -18,6 +18,7 @@ Unit tests for converter module
 from __future__ import annotations
 
 # standard
+import json
 import logging
 import platform
 import re
@@ -1251,6 +1252,143 @@ def test_convert_abi3_wheel(
     case.allow_impure = True
     pkg_path = case.build()
     assert "py312_abi3_0" in pkg_path.name
+
+
+# tags of a multi-platform ("fat") macosx wheel, in orjson's order (#201)
+FAT_WHEEL_TAGS = [
+    "cp313-cp313-macosx_10_15_x86_64",
+    "cp313-cp313-macosx_11_0_arm64",
+    "cp313-cp313-macosx_10_15_universal2",
+]
+
+
+def test_select_wheel_tag(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test platform tag selection for fat wheels (#201)."""
+    converter = Wheel2CondaConverter(Path("fake.whl"), Path("."))
+    converter.logger = logging.getLogger(__name__)
+
+    # single tag: chosen without further ado
+    assert (
+        converter._select_wheel_tag(["cp313-cp313-manylinux_2_17_x86_64"])
+        == "cp313-cp313-manylinux_2_17_x86_64"
+    )
+
+    # fat wheel: the current platform is preferred, with a warning
+    for native, expected in [
+        ("osx-arm64", "cp313-cp313-macosx_11_0_arm64"),
+        ("osx-64", "cp313-cp313-macosx_10_15_x86_64"),
+        # non-mac host: the universal2 rule selects osx-arm64, and the
+        # arch-specific arm64 tag is preferred within that subdir
+        ("linux-64", "cp313-cp313-macosx_11_0_arm64"),
+    ]:
+        monkeypatch.setattr(
+            "whl2conda.api.converter.native_conda_subdir", lambda sub=native: sub
+        )
+        caplog.clear()
+        with caplog.at_level(logging.WARNING):
+            assert converter._select_wheel_tag(FAT_WHEEL_TAGS) == expected
+        assert "multiple platforms" in caplog.text
+        assert "osx-arm64" in caplog.text and "osx-64" in caplog.text
+
+    # multiple tags for the same subdir: no warning, arch-specific preferred
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        assert (
+            converter._select_wheel_tag([
+                "cp39-abi3-macosx_10_15_universal2",
+                "cp39-abi3-macosx_11_0_arm64",
+            ])
+            == "cp39-abi3-macosx_11_0_arm64"
+        )
+        assert (
+            converter._select_wheel_tag([
+                "cp313-cp313-manylinux_2_17_x86_64",
+                "cp313-cp313-manylinux2014_x86_64",
+            ])
+            == "cp313-cp313-manylinux_2_17_x86_64"
+        )
+    assert not caplog.text
+
+
+def test_select_wheel_tag_override(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test explicit platform_tag override (#201)."""
+    converter = Wheel2CondaConverter(Path("fake.whl"), Path("."))
+    converter.logger = logging.getLogger(__name__)
+
+    converter.platform_tag = "macosx_10_15_x86_64"
+    with caplog.at_level(logging.WARNING):
+        assert (
+            converter._select_wheel_tag(FAT_WHEEL_TAGS)
+            == "cp313-cp313-macosx_10_15_x86_64"
+        )
+    assert not caplog.text
+
+    # case insensitive
+    converter.platform_tag = "MACOSX_10_15_UNIVERSAL2"
+    assert (
+        converter._select_wheel_tag(FAT_WHEEL_TAGS)
+        == "cp313-cp313-macosx_10_15_universal2"
+    )
+
+    converter.platform_tag = "win_amd64"
+    with pytest.raises(Wheel2CondaError, match=r"available:.*macosx_10_15_x86_64"):
+        converter._select_wheel_tag(FAT_WHEEL_TAGS)
+
+
+def test_convert_fat_wheel(
+    simple_wheel: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test end-to-end conversion of a fat macosx wheel (#201)."""
+    good_wheel = WheelFile(simple_wheel)
+    extract_dir = tmp_path / "extract"
+    good_wheel.extractall(str(extract_dir))
+    extract_info_dir = next(extract_dir.glob("*.dist-info"))
+
+    WHEEL_file = extract_info_dir / "WHEEL"
+    WHEEL_msg = Wheel2CondaConverter.read_metadata_file(WHEEL_file)
+    WHEEL_msg.replace_header("Root-Is-Purelib", "False")
+    del WHEEL_msg["Tag"]
+    for tag in FAT_WHEEL_TAGS:
+        WHEEL_msg["Tag"] = tag
+    WHEEL_file.write_text(WHEEL_msg.as_string(), encoding="utf8")
+
+    fat_wheel_name = simple_wheel.name.replace(
+        "py3-none-any",
+        "cp313-cp313-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2",
+    )
+    fat_wheel = tmp_path / "fat" / fat_wheel_name
+    fat_wheel.parent.mkdir(parents=True)
+    with WheelFile(str(fat_wheel), "w") as wf:
+        wf.write_files(str(extract_dir))
+
+    monkeypatch.setattr(
+        "whl2conda.api.converter.native_conda_subdir", lambda: "osx-arm64"
+    )
+
+    converter = Wheel2CondaConverter(fat_wheel, tmp_path / "out1")
+    converter.allow_impure = True
+    converter.convert()
+    assert converter.conda_target is not None
+    assert converter.conda_target.subdir == "osx-arm64"
+
+    # explicit override selects the other platform, with its __osx floor
+    converter = Wheel2CondaConverter(fat_wheel, tmp_path / "out2")
+    converter.allow_impure = True
+    converter.platform_tag = "macosx_10_15_x86_64"
+    converter.out_format = CondaPackageFormat.TREE
+    pkg_tree = converter.convert()
+    assert converter.conda_target is not None
+    assert converter.conda_target.subdir == "osx-64"
+    index = json.loads((pkg_tree / "info" / "index.json").read_text("utf8"))
+    assert index["subdir"] == "osx-64"
+    assert "__osx >=10.15" in index["depends"]
 
 
 def test_compute_conda_deps_with_marker_env() -> None:

--- a/test/cli/test_convert.py
+++ b/test/cli/test_convert.py
@@ -94,6 +94,7 @@ class CliTestCase:
     expected_overwrite: bool = False
     expected_package_name: str = ""
     expected_parser_error: str = ""
+    expected_platform_tag: str = ""
     """Relative path from projects dir"""
     expected_project_root: str = ""
     expected_python_version: str = ""
@@ -138,6 +139,7 @@ class CliTestCase:
         expected_overwrite: bool = False,
         expected_package_name: str = "",
         expected_parser_error: str = "",
+        expected_platform_tag: str = "",
         expected_project_root: str = "",
         expected_python_version: str = "",
         expected_wheel_path: str = "",
@@ -166,6 +168,7 @@ class CliTestCase:
         self.expected_overwrite = expected_overwrite
         self.expected_package_name = expected_package_name
         self.expected_parser_error = expected_parser_error
+        self.expected_platform_tag = expected_platform_tag
         self.expected_project_root = expected_project_root
         self.expected_prompts = []
         self.expected_python_version = expected_python_version
@@ -339,6 +342,7 @@ class CliTestCase:
         assert converter.overwrite is self.expected_overwrite
         assert converter.keep_pip_dependencies is self.expected_keep_pip
         assert converter.for_conda_forge is self.expected_for_conda_forge
+        assert converter.platform_tag == self.expected_platform_tag
         assert converter.extra_dependencies == list(self.expected_extra_dependencies)
         assert converter.dependency_rename == list(self.expected_dependency_renames)
         assert converter.python_version == self.expected_python_version
@@ -394,6 +398,7 @@ class CliTestCaseFactory:
         expected_dry_run: bool = False,
         expected_package_name: str = "",
         expected_parser_error: str = "",
+        expected_platform_tag: str = "",
         expected_out_dir: str = "",
         expected_out_fmt: CondaPackageFormat = CondaPackageFormat.V2,
         expected_overwrite: bool = False,
@@ -422,6 +427,7 @@ class CliTestCaseFactory:
             expected_dry_run=expected_dry_run,
             expected_package_name=expected_package_name,
             expected_parser_error=expected_parser_error,
+            expected_platform_tag=expected_platform_tag,
             expected_out_dir=expected_out_dir,
             expected_out_fmt=expected_out_fmt,
             expected_overwrite=expected_overwrite,
@@ -961,6 +967,17 @@ def test_python_override(
     """Test --python option"""
     test_case(
         [str(simple_wheel), "--python", ">=3.10"], expected_python_version=">=3.10"
+    ).run()
+
+
+def test_platform_tag(
+    test_case: CliTestCaseFactory,
+    simple_wheel: Path,
+) -> None:
+    """Test --platform-tag option (#201)"""
+    test_case(
+        [str(simple_wheel), "--platform-tag", "macosx_10_15_x86_64"],
+        expected_platform_tag="macosx_10_15_x86_64",
     ).run()
 
 


### PR DESCRIPTION
> [!NOTE]
> Stacked on #202 (updates its comparison manifest) — merge that first and this will retarget.

Fixes #201, found by the conda-forge comparison suite.

## Problem

A multi-platform ("fat") macosx wheel carries one `Tag:` line per supported platform in its WHEEL file. `_parse_wheel_info` picked the **first** python-3-compatible line — file order, host-independent — so orjson's `macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2` wheel always converted to an `osx-64` package, even on an arm64 host. The selected tag drives everything downstream (subdir/arch, the `__osx` floor, marker evaluation), so fixing selection fixes it all.

## Fix

New tag selection over all python-3-compatible tags:

1. `--platform-tag <tag>` (new experimental option / `Wheel2CondaConverter.platform_tag`) selects the target explicitly; an unmatched value errors listing the wheel's available platform tags.
2. Otherwise, tags are grouped by conda subdir. When the wheel spans multiple subdirs, the tag matching the current platform is preferred, then a `universal2` component (→ `osx-arm64` per the documented rule), with a warning naming the alternatives.
3. Within a subdir, an arch-specific tag is preferred over `universal2` so the `__osx` version floor is accurate (e.g. `>=11.0` for arm64 rather than the x86_64 tag's `>=10.15`).

Single-tag wheels and same-subdir compound tags (e.g. `manylinux_2_17_x86_64` + `manylinux2014_x86_64`) behave as before, with no warning.

## Verification

- New unit tests for selection (fake hosts via monkeypatched `native_conda_subdir`), the override, and an end-to-end fat-wheel conversion; CLI wiring test for `--platform-tag`.
- Real orjson 3.11.9 fat wheel on an arm64 host: converts to **osx-arm64** (with the multi-platform warning) and `whl2conda diff` against the conda-forge package reports **0 errors**; `--platform-tag macosx_10_15_x86_64` yields **osx-64** with `__osx >=10.15`.
- `pixi run compare-conda-forge`: orjson passes without xfail — now **10 of 12 clean** (only the documented bundled-libs cases remain xfailed).

Follow-up: generating packages for several platforms in one conversion is tracked by #204.

🤖 Generated with [Claude Code](https://claude.com/claude-code)