### PR TITLE
Add `--all-platforms` to convert fat wheels for every platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
   available programmatically as `whl2conda.api.compare`.
 * New `--platform-tag` option selects the wheel platform tag to convert
   for when converting a multi-platform ("fat") binary wheel (#201)
+* New `--all-platforms` option generates a conda package for every
+  platform supported by the wheel, each written into a `<subdir>/`
+  subdirectory of the output directory (#204)
 
 ### Changes
 

--- a/doc/guide/binary-conversion.md
+++ b/doc/guide/binary-conversion.md
@@ -203,8 +203,17 @@ whl2conda convert orjson-3.11.9-*.whl --allow-impure \
     --platform-tag macosx_10_15_x86_64
 ```
 
-There is currently no way to produce packages for several architectures
-in a single conversion.
+Alternatively, `--all-platforms` generates one package per supported
+platform in a single conversion, writing each package into a
+`<subdir>/` subdirectory of the output directory (packages for
+different platforms cannot share a directory, since conda package
+file names do not include the platform):
+
+```bash
+whl2conda convert orjson-3.11.9-*.whl --allow-impure --all-platforms
+# -> out-dir/osx-64/orjson-3.11.9-py313_0.conda
+#    out-dir/osx-arm64/orjson-3.11.9-py313_0.conda
+```
 
 ### No pre-compiled `.pyc` files
 

--- a/src/whl2conda/api/converter.py
+++ b/src/whl2conda/api/converter.py
@@ -572,6 +572,67 @@ class Wheel2CondaConverter:
         # TODO - option to ignore this
         self.std_renames = load_std_renames(update=update_std_renames)
 
+    def convert_all(self) -> list[Path]:
+        """
+        Convert wheel to a conda package for every platform it supports.
+
+        Produces one conda package per conda platform (subdir) supported
+        by the wheel, each written into a `<subdir>/` subdirectory of the
+        output directory - conda package file names do not include the
+        platform, so packages for multiple platforms cannot share a
+        directory. A pure python or single-platform wheel produces a
+        single package (under `noarch/` or its platform subdirectory).
+
+        Returns:
+            Paths of the converted conda packages.
+        """
+        packages: list[Path] = []
+        saved_out_dir = self.out_dir
+        saved_platform_tag = self.platform_tag
+        try:
+            for subdir, platform_tag in self._platform_groups().items():
+                self.out_dir = Path(saved_out_dir) / subdir
+                self.platform_tag = "" if platform_tag == "any" else platform_tag
+                packages.append(self.convert())
+        finally:
+            self.out_dir = saved_out_dir
+            self.platform_tag = saved_platform_tag
+        return packages
+
+    def _platform_groups(self) -> dict[str, str]:
+        """Preferred wheel platform tag per conda subdir of this wheel."""
+        with tempfile.TemporaryDirectory(prefix="whl2conda-") as temp_dirname:
+            extracted_wheel_dir = self._extract_wheel(Path(temp_dirname))
+            info_dir = next(extracted_wheel_dir.glob("*.dist-info"))
+            WHEEL_msg = self.read_metadata_file(info_dir / "WHEEL")
+        all_tags = WHEEL_msg.get_all("Tag") or ["py3-none-any"]
+
+        result: dict[str, str] = {}
+        for tag in all_tags:
+            if not tag.lower().partition("-")[0].startswith(("py3", "cp3")):
+                continue
+            platform_tag = tag.lower().rpartition("-")[2]
+            if platform_tag == "any":
+                subdir = "noarch"
+            else:
+                try:
+                    subdir, _arch, _platform = _parse_platform_tag(platform_tag)
+                except Wheel2CondaError:
+                    subdir = platform_tag
+            existing = result.get(subdir)
+            # prefer an arch-specific tag over universal2 (see
+            # _select_wheel_tag), otherwise keep the wheel's first tag
+            if existing is None or (
+                existing.endswith("universal2")
+                and not platform_tag.endswith("universal2")
+            ):
+                result[subdir] = platform_tag
+        if not result:
+            raise Wheel2CondaError(
+                f"Wheel {self.wheel_path} has no Python 3 compatible tag"
+            )
+        return result
+
     def convert(self) -> Path:
         """
         Convert wheel to conda package

--- a/src/whl2conda/cli/convert.py
+++ b/src/whl2conda/cli/convert.py
@@ -313,7 +313,8 @@ def _create_argparser(prog: str | None = None) -> argparse.ArgumentParser:
         """),
     )
 
-    experimental_opts.add_argument(
+    platform_opts = experimental_opts.add_mutually_exclusive_group()
+    platform_opts.add_argument(
         "--platform-tag",
         metavar="<tag>",
         default="",
@@ -324,15 +325,13 @@ def _create_argparser(prog: str | None = None) -> argparse.ArgumentParser:
             matching the current system is preferred.
         """),
     )
-
-    experimental_opts.add_argument(
+    platform_opts.add_argument(
         "--all-platforms",
         action="store_true",
         help=dedent("""
             Generate a conda package for every platform supported by
             the wheel, each written into a <subdir>/ subdirectory of
-            the output directory (e.g. osx-arm64/). May not be
-            combined with --platform-tag.
+            the output directory (e.g. osx-arm64/).
         """),
     )
 
@@ -460,9 +459,6 @@ def convert_main(args: Sequence[str] | None = None, prog: str | None = None):
                 "--download-platform, --download-python-version, and --download-abi "
                 "require --from-pypi or --from-index"
             )
-
-    if parsed.all_platforms and parsed.platform_tag:
-        parser.error("--all-platforms cannot be combined with --platform-tag")
 
     wheel_or_root = parsed.wheel_or_root
     saw_positional_root = False

--- a/src/whl2conda/cli/convert.py
+++ b/src/whl2conda/cli/convert.py
@@ -52,6 +52,7 @@ class ConvertArgs:
     Parsed arguments
     """
 
+    all_platforms: bool
     allow_impure: bool
     allow_metadata_version: str
     build_number: int | None
@@ -325,6 +326,17 @@ def _create_argparser(prog: str | None = None) -> argparse.ArgumentParser:
     )
 
     experimental_opts.add_argument(
+        "--all-platforms",
+        action="store_true",
+        help=dedent("""
+            Generate a conda package for every platform supported by
+            the wheel, each written into a <subdir>/ subdirectory of
+            the output directory (e.g. osx-arm64/). May not be
+            combined with --platform-tag.
+        """),
+    )
+
+    experimental_opts.add_argument(
         "--download-platform",
         metavar="<tag>",
         help=dedent("""
@@ -448,6 +460,9 @@ def convert_main(args: Sequence[str] | None = None, prog: str | None = None):
                 "--download-platform, --download-python-version, and --download-abi "
                 "require --from-pypi or --from-index"
             )
+
+    if parsed.all_platforms and parsed.platform_tag:
+        parser.error("--all-platforms cannot be combined with --platform-tag")
 
     wheel_or_root = parsed.wheel_or_root
     saw_positional_root = False
@@ -635,7 +650,10 @@ def convert_main(args: Sequence[str] | None = None, prog: str | None = None):
 
         converter.dependency_rename.extend(renames)
 
-        _conda_package = converter.convert()
+        if parsed.all_platforms:
+            converter.convert_all()
+        else:
+            converter.convert()
 
 
 def do_build_wheel(

--- a/test/api/test_converter.py
+++ b/test/api/test_converter.py
@@ -1372,30 +1372,39 @@ def test_select_wheel_tag_override(
         converter._select_wheel_tag(FAT_WHEEL_TAGS)
 
 
-def _build_fat_wheel(simple_wheel: Path, work_dir: Path) -> Path:
-    """Rebuild the simple wheel as a fat macosx binary wheel."""
+def _rebuild_wheel_tags(
+    simple_wheel: Path,
+    work_dir: Path,
+    tags: list[str],
+    label: str,
+    *,
+    purelib: bool = False,
+) -> Path:
+    """Rebuild the simple wheel with the given WHEEL tags."""
     good_wheel = WheelFile(simple_wheel)
-    extract_dir = work_dir / "extract"
+    extract_dir = work_dir / f"extract-{label}"
     good_wheel.extractall(str(extract_dir))
     extract_info_dir = next(extract_dir.glob("*.dist-info"))
 
     WHEEL_file = extract_info_dir / "WHEEL"
     WHEEL_msg = Wheel2CondaConverter.read_metadata_file(WHEEL_file)
-    WHEEL_msg.replace_header("Root-Is-Purelib", "False")
+    WHEEL_msg.replace_header("Root-Is-Purelib", str(purelib))
     del WHEEL_msg["Tag"]
-    for tag in FAT_WHEEL_TAGS:
+    for tag in tags:
         WHEEL_msg["Tag"] = tag
     WHEEL_file.write_text(WHEEL_msg.as_string(), encoding="utf8")
 
-    fat_wheel_name = simple_wheel.name.replace(
-        "py3-none-any",
-        "cp313-cp313-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2",
-    )
-    fat_wheel = work_dir / "fat" / fat_wheel_name
-    fat_wheel.parent.mkdir(parents=True)
-    with WheelFile(str(fat_wheel), "w") as wf:
+    wheel_name = simple_wheel.name.replace("py3-none-any", tags[0])
+    wheel = work_dir / label / wheel_name
+    wheel.parent.mkdir(parents=True)
+    with WheelFile(str(wheel), "w") as wf:
         wf.write_files(str(extract_dir))
-    return fat_wheel
+    return wheel
+
+
+def _build_fat_wheel(simple_wheel: Path, work_dir: Path) -> Path:
+    """Rebuild the simple wheel as a fat macosx binary wheel."""
+    return _rebuild_wheel_tags(simple_wheel, work_dir, FAT_WHEEL_TAGS, "fat")
 
 
 def test_convert_fat_wheel(
@@ -1463,6 +1472,44 @@ def test_convert_all_platforms(
     assert packages[0].parent == tmp_path / "pure" / "noarch"
     index = json.loads((packages[0] / "info" / "index.json").read_text("utf8"))
     assert index["subdir"] == "noarch"
+
+
+def test_platform_groups(
+    simple_wheel: Path,
+    tmp_path: Path,
+) -> None:
+    """Test _platform_groups tag handling (#204)."""
+    # non-python-3 tags are skipped; pure wheels map to noarch
+    wheel = _rebuild_wheel_tags(
+        simple_wheel,
+        tmp_path,
+        ["py2-none-any", "py3-none-any"],
+        "mixed",
+        purelib=True,
+    )
+    converter = Wheel2CondaConverter(wheel, tmp_path)
+    assert converter._platform_groups() == {"noarch": "any"}
+
+    # unsupported platform tags are kept in their own group
+    wheel = _rebuild_wheel_tags(
+        simple_wheel,
+        tmp_path,
+        ["cp313-cp313-freebsd_14_x86_64", "cp313-cp313-macosx_11_0_arm64"],
+        "exotic",
+    )
+    converter = Wheel2CondaConverter(wheel, tmp_path)
+    assert converter._platform_groups() == {
+        "freebsd_14_x86_64": "freebsd_14_x86_64",
+        "osx-arm64": "macosx_11_0_arm64",
+    }
+
+    # no python 3 compatible tag at all
+    wheel = _rebuild_wheel_tags(
+        simple_wheel, tmp_path, ["py2-none-any"], "py2", purelib=True
+    )
+    converter = Wheel2CondaConverter(wheel, tmp_path)
+    with pytest.raises(Wheel2CondaError, match="no Python 3 compatible tag"):
+        converter._platform_groups()
 
 
 def test_compute_conda_deps_with_marker_env() -> None:

--- a/test/api/test_converter.py
+++ b/test/api/test_converter.py
@@ -1372,14 +1372,10 @@ def test_select_wheel_tag_override(
         converter._select_wheel_tag(FAT_WHEEL_TAGS)
 
 
-def test_convert_fat_wheel(
-    simple_wheel: Path,
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Test end-to-end conversion of a fat macosx wheel (#201)."""
+def _build_fat_wheel(simple_wheel: Path, work_dir: Path) -> Path:
+    """Rebuild the simple wheel as a fat macosx binary wheel."""
     good_wheel = WheelFile(simple_wheel)
-    extract_dir = tmp_path / "extract"
+    extract_dir = work_dir / "extract"
     good_wheel.extractall(str(extract_dir))
     extract_info_dir = next(extract_dir.glob("*.dist-info"))
 
@@ -1395,10 +1391,20 @@ def test_convert_fat_wheel(
         "py3-none-any",
         "cp313-cp313-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2",
     )
-    fat_wheel = tmp_path / "fat" / fat_wheel_name
+    fat_wheel = work_dir / "fat" / fat_wheel_name
     fat_wheel.parent.mkdir(parents=True)
     with WheelFile(str(fat_wheel), "w") as wf:
         wf.write_files(str(extract_dir))
+    return fat_wheel
+
+
+def test_convert_fat_wheel(
+    simple_wheel: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test end-to-end conversion of a fat macosx wheel (#201)."""
+    fat_wheel = _build_fat_wheel(simple_wheel, tmp_path)
 
     monkeypatch.setattr(
         "whl2conda.api.converter.native_conda_subdir", lambda: "osx-arm64"
@@ -1421,6 +1427,42 @@ def test_convert_fat_wheel(
     index = json.loads((pkg_tree / "info" / "index.json").read_text("utf8"))
     assert index["subdir"] == "osx-64"
     assert "__osx >=10.15" in index["depends"]
+
+
+def test_convert_all_platforms(
+    simple_wheel: Path,
+    tmp_path: Path,
+) -> None:
+    """Test conversion of a fat wheel for all platforms (#204)."""
+    fat_wheel = _build_fat_wheel(simple_wheel, tmp_path)
+
+    converter = Wheel2CondaConverter(fat_wheel, tmp_path / "all")
+    converter.allow_impure = True
+    converter.out_format = CondaPackageFormat.TREE
+    packages = converter.convert_all()
+
+    assert [pkg.parent.name for pkg in packages] == ["osx-64", "osx-arm64"]
+    for pkg, subdir, osx_constraint in [
+        (packages[0], "osx-64", "__osx >=10.15"),
+        (packages[1], "osx-arm64", "__osx >=11.0"),
+    ]:
+        assert pkg.parent.parent == tmp_path / "all"
+        index = json.loads((pkg / "info" / "index.json").read_text("utf8"))
+        assert index["subdir"] == subdir
+        assert osx_constraint in index["depends"]
+
+    # converter settings are restored afterwards
+    assert converter.out_dir == tmp_path / "all"
+    assert converter.platform_tag == ""
+
+    # pure python wheel: a single package under noarch/
+    converter = Wheel2CondaConverter(simple_wheel, tmp_path / "pure")
+    converter.out_format = CondaPackageFormat.TREE
+    packages = converter.convert_all()
+    assert len(packages) == 1
+    assert packages[0].parent == tmp_path / "pure" / "noarch"
+    index = json.loads((packages[0] / "info" / "index.json").read_text("utf8"))
+    assert index["subdir"] == "noarch"
 
 
 def test_compute_conda_deps_with_marker_env() -> None:

--- a/test/cli/test_convert.py
+++ b/test/cli/test_convert.py
@@ -981,6 +981,29 @@ def test_platform_tag(
     ).run()
 
 
+def test_all_platforms(
+    test_case: CliTestCaseFactory,
+    simple_wheel: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test --all-platforms option (#204)"""
+    convert_all_called = False
+
+    def fake_convert_all(converter: Wheel2CondaConverter) -> list[Path]:
+        nonlocal convert_all_called
+        convert_all_called = True
+        return [converter.convert()]
+
+    monkeypatch.setattr(Wheel2CondaConverter, "convert_all", fake_convert_all)
+    test_case([str(simple_wheel), "--all-platforms"]).run()
+    assert convert_all_called
+
+    test_case(
+        [str(simple_wheel), "--all-platforms", "--platform-tag", "win_amd64"],
+        expected_parser_error="cannot be combined with --platform-tag",
+    ).run()
+
+
 def test_for_conda_forge(
     test_case: CliTestCaseFactory,
     simple_wheel: Path,

--- a/test/cli/test_convert.py
+++ b/test/cli/test_convert.py
@@ -1000,7 +1000,7 @@ def test_all_platforms(
 
     test_case(
         [str(simple_wheel), "--all-platforms", "--platform-tag", "win_amd64"],
-        expected_parser_error="cannot be combined with --platform-tag",
+        expected_parser_error="not allowed with argument --all-platforms",
     ).run()
 
 


### PR DESCRIPTION
Fixes #204 (follow-up to #201/#205).

New `Wheel2CondaConverter.convert_all()` converts a multi-platform ("fat") wheel once per conda platform it supports, exposed as the `--all-platforms` convert option (mutually exclusive with `--platform-tag`):

- One package per conda subdir, each written into a channel-style `<subdir>/` subdirectory of the output directory — required because conda package file names don't include the platform, so multiple targets would collide in a flat directory.
- Each conversion runs the full pipeline for its target, so `index.json` (`subdir`/`arch`), the `__osx >=X.Y` floor, and marker-evaluated dependencies are computed per platform. Within a subdir the arch-specific tag is preferred over `universal2` (same rule as #205).
- Pure-python and single-platform wheels produce a single package (under `noarch/` or their platform subdir), keeping the layout uniform.

## Verification

- Unit tests: fat wheel → `osx-64/` + `osx-arm64/` trees with correct subdirs and `__osx` floors, converter state restored afterwards; pure wheel → single `noarch/` package; CLI dispatch and mutual-exclusion tests.
- Real orjson 3.11.9 fat wheel:
  ```
  out-dir/osx-64/orjson-3.11.9-py313_0.conda      (subdir osx-64,   __osx >=10.15)
  out-dir/osx-arm64/orjson-3.11.9-py313_0.conda   (subdir osx-arm64, __osx >=11.0)
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)