### PR TITLE
Graduate binary conversion from experimental status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@
 
 ### Changes
 
+* Binary wheel conversion (`--allow-impure`) is no longer labeled
+  experimental: conversions of representative C, C++, Cython, rust, and
+  abi3 extension packages are verified to be semantically equivalent to
+  the corresponding conda-forge packages on linux, macOS, and windows by
+  the new comparison suite. The converter now emits a targeted warning
+  when a wheel bundles vendored shared libraries (the main remaining
+  limitation) instead of a blanket experimental warning on every binary
+  conversion.
 * `whl2conda install` no longer checks the conda-libmamba-solver version
   or switches target environments to the classic solver. That workaround
   was only needed for conda-libmamba-solver older than 24.1.0, which fixed

--- a/README.md
+++ b/README.md
@@ -45,17 +45,22 @@ generated directly from pure python wheels.
 * **Hides pypi dependencies**: rewrites the original pip/pypi dependencies in the
     installed dist-info to avoid [compatibility issues](https://zuzukin.github.io/whl2conda/latest/guide/renaming.html#hide-pip).
 
-* **Experimental binary support**: can convert non-pure Python wheels containing
+* **Binary wheel support**: can convert non-pure Python wheels containing
     binary extensions (`.so`, `.pyd`) into platform-specific conda packages using
     the `--allow-impure` flag. Automatically generates tight Python version pins
-    and OS constraints from wheel platform tags.
+    and OS constraints from wheel platform tags, with special support for
+    stable ABI (abi3) and multi-platform (fat) wheels. Conversions of
+    representative C, C++, Cython, rust, and abi3 extension packages are
+    regularly verified to be equivalent to the corresponding conda-forge
+    packages on linux, macOS, and windows.
 
-    **Limitations**: Binary conversion works best for **simple C extension packages**
-    (e.g., markupsafe, wrapt, ujson) where the wheel is self-contained. It will
-    refuse to convert packages known to bundle complex runtime libraries (PyTorch,
-    TensorFlow, CUDA packages, etc.) or wheels with local version suffixes
-    (e.g., `+cu121`). For complex GPU/CUDA packages, use conda-forge
-    packages instead.
+    **Limitations**: Binary conversion is designed for **self-contained
+    extension packages** (e.g., markupsafe, cryptography, orjson). Wheels
+    that bundle vendored shared libraries (e.g., lxml, pillow) convert with
+    a warning but bypass conda's dependency management for those libraries,
+    and wheels with local version suffixes (e.g., `+cu121` variant builds)
+    are refused. For complex GPU/CUDA packages, use conda-forge packages
+    instead.
 
 
 ## Installation

--- a/doc/guide/binary-conversion.md
+++ b/doc/guide/binary-conversion.md
@@ -1,9 +1,5 @@
 # Binary Wheel Conversion
 
-!!! warning "Experimental"
-    Binary wheel conversion is an experimental feature. The generated conda
-    packages may not work correctly for all packages. Use with caution.
-
 ## Overview
 
 By default, **whl2conda** converts pure Python wheels (`py3-none-any`) into
@@ -132,15 +128,19 @@ are still skipped, since noarch packages are platform-independent.
 
 ## What works well
 
-Binary conversion is best suited for **simple C/C++ extension packages** where
-the wheel is self-contained — all compiled code is bundled in the wheel and
-runtime dependencies are available as conda packages. Examples include:
+Binary conversion is suited for **self-contained extension packages**,
+where all compiled code (including any statically linked libraries) is
+bundled in the wheel and the package's runtime dependencies are
+available as conda packages. The comparison suite described below
+verifies — on linux, macOS, and windows — that converted packages for
+all of the following kinds of wheels are semantically equivalent to
+the corresponding conda-forge packages:
 
-- **markupsafe** — simple C speedups
-- **wrapt** — C extension for decorators
-- **ujson** — fast JSON parser
-- **pyyaml** — YAML parser with C library (libyaml)
-- **msgpack** — MessagePack serializer
+- **C/C++ extensions** — e.g. markupsafe, wrapt, ujson, psutil
+- **Cython extensions** — e.g. pyyaml, msgpack (including statically
+  linked C libraries such as libyaml)
+- **Rust extensions** — e.g. orjson, rpds-py
+- **Stable ABI (abi3) extensions** — e.g. cryptography, bcrypt
 
 ## Validation against conda-forge
 
@@ -149,7 +149,7 @@ converts a curated sample of representative binary PyPI packages
 (C extensions, Cython, stable-ABI and non-abi3 rust extensions, and
 packages with bundled libraries) and semantically compares each result
 against the real conda-forge package of the same version using
-`whl2conda diff`. Developers can run it with:
+`whl2conda diff`. It runs monthly in CI and developers can run it with:
 
 ```bash
 pixi run compare-conda-forge
@@ -157,36 +157,64 @@ pixi run compare-conda-forge
 
 This requires network access, downloads packages from PyPI and
 anaconda.org (cached across runs), and writes a summary report to
-`compare-report.md` / `compare-report.json`. The results of this suite
-are the evidence base for eventually removing the experimental label
-from binary conversion.
+`compare-report.md` / `compare-report.json`.
+
+To vet your own conversion, compare it against a reference package
+built from a recipe (if one exists) using
+[`whl2conda diff`](testing.md#comparing-packages), and install and
+test it with [`whl2conda install`](testing.md).
 
 ## Known limitations
+
+The converter detects and refuses the known-bad cases it can identify:
+wheels that are not pure python (without `--allow-impure`), unsupported
+wheel platform tags, and local version suffixes (below). It warns about
+wheels that bundle shared libraries. The remaining limitations listed
+here are inherent to wheel conversion and are the user's responsibility
+to evaluate.
 
 ### Local version suffixes
 
 Wheels with local version suffixes (e.g. `torch-2.1.0+cu121`) indicate
-custom build variants such as CUDA-specific builds. These are blocked because
-they bundle variant-specific libraries that require careful dependency
-management not possible through simple wheel conversion.
+custom build variants such as CUDA-specific builds. These are **blocked
+with an error** because they bundle variant-specific libraries that
+require careful dependency management not possible through simple wheel
+conversion.
 
 ### Bundled shared libraries
 
-Binary wheels may bundle shared libraries (`.so`, `.dylib`, `.dll`) that
-overlap with or conflict with libraries provided by other conda packages.
-The converted package includes these bundled copies as-is, which can lead to:
+Binary wheels repaired by tools like auditwheel, delocate, or
+delvewheel bundle copies of the shared libraries they link against
+(in `<package>.libs/` or `.dylibs/` directories). The converter
+**warns** when it detects such vendored libraries. The converted
+package includes these bundled copies as-is — unlike an equivalent
+conda-forge package, which would declare shared library dependencies
+instead — which can lead to:
 
 - **Version conflicts** with conda-installed libraries
 - **Missing transitive dependencies** not declared in the wheel metadata
 - **ABI incompatibilities** when mixed with conda-forge packages
+
+This usually *works* (the same copies are used from PyPI installs), but
+duplicates libraries in the environment and bypasses conda's dependency
+management for them.
 
 ### No `run_exports` or build metadata
 
 Unlike conda-forge packages, converted wheels lack `run_exports` and detailed
 build metadata. Downstream packages that depend on the converted package will
 not automatically inherit correct library dependencies. You may need to manually
-specify additional dependencies using the `-A`/`--add-dependency` flag 
-during conversion.
+specify additional dependencies using the `-A`/`--add-dependency` flag
+during conversion. *Not detected by the converter.*
+
+### Dependencies must exist on the target channel
+
+Dependency names are renamed using the standard pypi-to-conda rename
+table (plus any project-specific renames), but the converter does not
+verify that the resulting conda packages actually exist on the channel
+you will install from. A missing or incorrectly named dependency only
+surfaces when the package is installed. *Not detected by the converter* —
+test with [`whl2conda install`](testing.md).
 
 ### Multi-platform (fat) macOS wheels
 

--- a/doc/guide/limitations.md
+++ b/doc/guide/limitations.md
@@ -50,9 +50,8 @@ in a future release. See [issue 36](https://github.com/zuzukin/whl2conda/issues/
 
 By default, only generic python conda packages with `noarch: python` will be generated.
 
-Experimental support for converting binary wheels is available using the
-`--allow-impure` flag. See the [Binary Conversion](binary-conversion.md) guide
-for details and limitations.
+Binary wheels can be converted using the `--allow-impure` flag. See the
+[Binary Conversion](binary-conversion.md) guide for details and limitations.
 
 ## Dependencies with environment markers
 

--- a/linkcheckerrc.ini
+++ b/linkcheckerrc.ini
@@ -8,6 +8,8 @@ checkextern=1
 #   checked through their relative file paths in site/.
 # - Site-root-absolute paths (from 404.html): these cannot resolve when
 #   checking the local site/ directory over file://.
+# - anaconda.org intermittently returns 403 to link checkers.
 ignore=
   ^https://zuzukin\.github\.io/whl2conda/
   ^file:///whl2conda/
+  ^https://anaconda\.org/

--- a/src/whl2conda/api/converter.py
+++ b/src/whl2conda/api/converter.py
@@ -691,12 +691,8 @@ class Wheel2CondaConverter:
 
             # Add binary-specific dependencies
             if not conda_target.is_noarch:
-                self._warn(
-                    "Experimental: converting non-pure wheel '%s'. "
-                    "Converted package may include bundled libraries that "
-                    "differ from conda-forge shared library packages.",
-                    self.wheel_path.name,
-                )
+                self._info("Converting non-pure wheel '%s'", self.wheel_path.name)
+                self._warn_vendored_libraries(rel_files)
                 conda_dependencies = self._add_binary_dependencies(
                     conda_dependencies, conda_target, wheel_md.platform_tag
                 )
@@ -1111,6 +1107,32 @@ class Wheel2CondaConverter:
 
     # Known package prefixes that are unlikely to work as binary conversions
     # due to bundled GPU libraries, complex runtime dependencies, etc.
+    # directories used by wheel repair tools (auditwheel, delocate,
+    # delvewheel) to vendor shared libraries into the wheel
+    _VENDORED_LIB_DIR_RE = re.compile(r"(?:^|/)(?P<dir>[^/]+\.libs|\.dylibs)/")
+
+    def _warn_vendored_libraries(self, rel_files: Sequence[str]) -> None:
+        """Warn if the wheel vendors shared libraries.
+
+        Wheels repaired by auditwheel/delocate/delvewheel bundle copies
+        of the shared libraries they link against. The converted conda
+        package will use those bundled copies, unlike an equivalent
+        conda-forge package, which would declare shared library
+        dependencies instead.
+        """
+        vendored = sorted({
+            m.group("dir")
+            for relpath in rel_files
+            if (m := self._VENDORED_LIB_DIR_RE.search(relpath))
+        })
+        if vendored:
+            self._warn(
+                "Wheel bundles shared libraries (%s). The converted package "
+                "will use these bundled copies, which may conflict with or "
+                "duplicate libraries provided by conda packages.",
+                ", ".join(vendored),
+            )
+
     def _check_binary_conversion(self, wheel_md: MetadataFromWheel) -> None:
         """Check for conditions that make binary conversion unlikely to succeed.
 

--- a/src/whl2conda/cli/convert.py
+++ b/src/whl2conda/cli/convert.py
@@ -108,7 +108,7 @@ def _create_argparser(prog: str | None = None) -> argparse.ArgumentParser:
     input_opts = parser.add_argument_group("Input options")
     output_opts = parser.add_argument_group("Output options")
     override_opts = parser.add_argument_group("Override options")
-    experimental_opts = parser.add_argument_group("Experimental options")
+    binary_opts = parser.add_argument_group("Binary conversion options")
     info_opts = parser.add_argument_group("Help and debug options")
 
     input_opts.add_argument(
@@ -287,19 +287,19 @@ def _create_argparser(prog: str | None = None) -> argparse.ArgumentParser:
         help="Set/override python dependency.",
     )
 
-    experimental_opts.add_argument(
+    binary_opts.add_argument(
         "--allow-impure",
         action="store_true",
         help=dedent("""
-            Allow experimental conversion of non-pure python wheels
-            containing binary extensions into platform-specific conda packages.
+            Allow conversion of non-pure python wheels containing
+            binary extensions into platform-specific conda packages.
             Generates tight Python version pins and OS constraints from wheel
             tags. Stable ABI (abi3) wheels are only pinned to a minimum python
             version. Use --python to override the generated python dependency.
         """),
     )
 
-    experimental_opts.add_argument(
+    binary_opts.add_argument(
         "--for-conda-forge",
         "--for-cpython",
         dest="for_conda_forge",
@@ -313,7 +313,7 @@ def _create_argparser(prog: str | None = None) -> argparse.ArgumentParser:
         """),
     )
 
-    platform_opts = experimental_opts.add_mutually_exclusive_group()
+    platform_opts = binary_opts.add_mutually_exclusive_group()
     platform_opts.add_argument(
         "--platform-tag",
         metavar="<tag>",
@@ -335,7 +335,7 @@ def _create_argparser(prog: str | None = None) -> argparse.ArgumentParser:
         """),
     )
 
-    experimental_opts.add_argument(
+    binary_opts.add_argument(
         "--download-platform",
         metavar="<tag>",
         help=dedent("""
@@ -345,7 +345,7 @@ def _create_argparser(prog: str | None = None) -> argparse.ArgumentParser:
             Implies --allow-impure.
         """),
     )
-    experimental_opts.add_argument(
+    binary_opts.add_argument(
         "--download-python-version",
         metavar="<ver>",
         help=dedent("""
@@ -353,7 +353,7 @@ def _create_argparser(prog: str | None = None) -> argparse.ArgumentParser:
             Used with --from-pypi or --from-index.
         """),
     )
-    experimental_opts.add_argument(
+    binary_opts.add_argument(
         "--download-abi",
         metavar="<tag>",
         help=dedent("""

--- a/test/api/test_converter.py
+++ b/test/api/test_converter.py
@@ -1474,6 +1474,54 @@ def test_convert_all_platforms(
     assert index["subdir"] == "noarch"
 
 
+def test_vendored_library_warning(
+    simple_wheel: Path,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test warning for wheels bundling vendored shared libraries."""
+    # rebuild the simple wheel with an auditwheel-style .libs directory
+    good_wheel = WheelFile(simple_wheel)
+    extract_dir = tmp_path / "extract"
+    good_wheel.extractall(str(extract_dir))
+    extract_info_dir = next(extract_dir.glob("*.dist-info"))
+
+    WHEEL_file = extract_info_dir / "WHEEL"
+    WHEEL_msg = Wheel2CondaConverter.read_metadata_file(WHEEL_file)
+    WHEEL_msg.replace_header("Root-Is-Purelib", "False")
+    WHEEL_msg.replace_header("Tag", "cp312-cp312-manylinux_2_17_x86_64")
+    WHEEL_file.write_text(WHEEL_msg.as_string(), encoding="utf8")
+
+    libs_dir = extract_dir / "simple.libs"
+    libs_dir.mkdir()
+    (libs_dir / "libfoo-1234abcd.so.1").write_bytes(b"\x7fELF-fake")
+
+    wheel_name = simple_wheel.name.replace(
+        "py3-none-any", "cp312-cp312-manylinux_2_17_x86_64"
+    )
+    vendored_wheel = tmp_path / "vendored" / wheel_name
+    vendored_wheel.parent.mkdir(parents=True)
+    with WheelFile(str(vendored_wheel), "w") as wf:
+        wf.write_files(str(extract_dir))
+
+    converter = Wheel2CondaConverter(vendored_wheel, tmp_path / "out")
+    converter.allow_impure = True
+    with caplog.at_level(logging.WARNING):
+        converter.convert()
+    assert "bundles shared libraries" in caplog.text
+    assert "simple.libs" in caplog.text
+
+    # no warning for a binary wheel without vendored libraries
+    caplog.clear()
+    fat_wheel = _build_fat_wheel(simple_wheel, tmp_path / "plain")
+    converter = Wheel2CondaConverter(fat_wheel, tmp_path / "out2")
+    converter.allow_impure = True
+    converter.platform_tag = "macosx_11_0_arm64"
+    with caplog.at_level(logging.WARNING):
+        converter.convert()
+    assert "bundles shared libraries" not in caplog.text
+
+
 def test_platform_groups(
     simple_wheel: Path,
     tmp_path: Path,


### PR DESCRIPTION
Removes the "experimental" labeling from binary wheel conversion, backed by the comparison-suite evidence: converted packages for representative **C, C++, Cython, rust, and abi3** extension packages are semantically equivalent to the corresponding conda-forge packages on **linux, macOS, and windows** (per the `compare-conda-forge` workflow, which now runs monthly).

## Label removal

- `doc/guide/binary-conversion.md`: experimental admonition removed; "What works well" rewritten around the verified categories; the validation section now describes the suite as ongoing verification rather than pending evidence.
- `doc/guide/limitations.md`, `README.md`: "experimental" wording dropped (README now also mentions abi3/fat-wheel support and the verification).
- `whl2conda convert --help`: the option group is renamed from "Experimental options" to "Binary conversion options", and `--allow-impure` no longer says "experimental". (The separate `whl2conda build` experimental label is untouched.)

## Detected vs. user-judgment cases

The docs now state explicitly which bad cases the converter handles:

- **Refused with an error**: non-pure wheels without `--allow-impure`; unsupported platform tags; local version suffixes (`+cu121` variant builds); non-matching `--platform-tag`.
- **Warned**: wheels that **bundle vendored shared libraries** — the blanket "Experimental" warning previously emitted on *every* binary conversion is replaced by a targeted warning that fires only when auditwheel/delocate/delvewheel-style `*.libs/` or `.dylibs/` directories are actually present, naming them. Verified against the real pillow wheel (warns on `.dylibs`) and clean wheels (no warning). Multi-platform wheels already warn about the platform choice.
- **User's responsibility** (documented as such): no `run_exports` for downstream consumers, and no verification that renamed dependencies exist on the target channel (surfaces at install time; a possible future `--check-deps` could use the anaconda.org client).

Also enables the linkchecker ignore for anaconda.org (intermittently 403s link checkers; the config file already anticipated this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)