### PR TITLE
Add CEP-20 to the reference links page

### DIFF
--- a/doc/reference/links.md
+++ b/doc/reference/links.md
@@ -3,6 +3,7 @@
 
 * [conda file format](https://docs.conda.io/projects/conda/en/latest/user-guide/concepts/packages.html)
 * [package spec](https://docs.conda.io/projects/conda-build/en/stable/resources/package-spec.html)
+* [CEP-20](https://conda.org/learn/ceps/cep-0020/) - support for abi3 python packages
 * [conda-package-handling tool (cph)](https://conda.github.io/conda-package-handling/)
 * [conda-build](https://docs.conda.io/projects/conda-build/)
 


### PR DESCRIPTION
Adds the CEP-20 (abi3 python packages) spec to the Conda section of the reference links page, alongside the other format specifications whl2conda implements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)