### PR TITLE
Support render-only and test-only build modes (#110)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,20 +4,20 @@
 
 ### Features
 
-* `whl2conda build` now supports the render-only and test-only
-  `conda build` modes: `--output` prints the predicted package path
-  without building, `-t`/`--test` runs the recipe tests against the
-  already-built package, and `--skip-existing` skips the build when the
-  package already exists. The new whl2conda extension `--check` renders
-  the recipe and verifies whl2conda can build it, without building
-  anything. (#110)
 * `whl2conda build` now supports most applicable `conda build` options:
-  `--output-folder`, `--package-format`, `--croot`, `--python`,
-  `-b`/`--build-only`, `-q`/`--quiet`, `--debug`, and the whl2conda
-  extensions `--extra-deps` and `--keep-test-env`. Inapplicable
-  conda build options are accepted and ignored with a warning, except
-  upload/signing and non-python language options, which are rejected
-  with an error. (#110)
+  the build modes `--output` (print the predicted package path without
+  building), `-t`/`--test` (test the already-built package),
+  `-b`/`--build-only`, and `--skip-existing`, plus `--output-folder`,
+  `--package-format`, `--croot`, `--python`, `-q`/`--quiet`, and
+  `--debug`. Inapplicable conda build options are accepted and ignored
+  with a warning, except upload/signing and non-python language
+  options, which are rejected with an error. (#110)
+* New `whl2conda build` extension options: `--check` renders the recipe
+  and verifies whl2conda can build it, without building anything;
+  `--extra-deps` adds conda dependencies to the generated package;
+  `--keep-test-env` keeps the test environment for debugging; and
+  `--mamba` uses mamba to create test environments and to run
+  conda-build when it must be run in the base environment. (#110)
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Features
 
+* `whl2conda build` now supports the render-only and test-only
+  `conda build` modes: `--output` prints the predicted package path
+  without building, `-t`/`--test` runs the recipe tests against the
+  already-built package, and `--skip-existing` skips the build when the
+  package already exists. The new whl2conda extension `--check` renders
+  the recipe and verifies whl2conda can build it, without building
+  anything. (#110)
 * `whl2conda build` now supports most applicable `conda build` options:
   `--output-folder`, `--package-format`, `--croot`, `--python`,
   `-b`/`--build-only`, `-q`/`--quiet`, `--debug`, and the whl2conda
@@ -19,6 +26,11 @@
   scratch space in conda-bld), checks the exit status of the render,
   uses conda-build in-process when it is importable, and reports
   build errors clearly. (#110)
+
+### Bug fixes
+
+* The build string of generated noarch packages now includes the build
+  number (e.g. `py_1`) instead of always being `py_0`. (#110)
 
 ### Development
 

--- a/src/whl2conda/api/converter.py
+++ b/src/whl2conda/api/converter.py
@@ -54,8 +54,14 @@ __all__ = [
     "DependencyRename",
     "Wheel2CondaConverter",
     "Wheel2CondaError",
+    "noarch_build_string",
     "normalize_pypi_name",
 ]
+
+
+def noarch_build_string(build_number: int = 0) -> str:
+    """Build string used for generated noarch python packages."""
+    return f"py_{build_number}"
 
 
 def __compile_requires_dist_re() -> re.Pattern:
@@ -310,7 +316,7 @@ class CondaTargetInfo:
                 subdir="noarch",
                 arch=None,
                 platform=None,
-                build_string="py_0",
+                build_string=noarch_build_string(build_number),
                 is_noarch=True,
                 site_packages_prefix="site-packages",
             )

--- a/src/whl2conda/cli/build.py
+++ b/src/whl2conda/cli/build.py
@@ -28,7 +28,12 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import ClassVar
 
-from ..api.converter import CondaPackageFormat, Wheel2CondaConverter
+from ..api.converter import (
+    CondaPackageFormat,
+    Wheel2CondaConverter,
+    noarch_build_string,
+    normalize_pypi_name,
+)
 
 # this project
 from ..impl.recipe import (
@@ -37,13 +42,51 @@ from ..impl.recipe import (
     render_recipe,
     rewrite_build_script,
 )
-from .common import add_markdown_help, dedent, existing_dir, maybe_existing_dir
+from .common import (
+    add_markdown_help,
+    dedent,
+    existing_dir,
+    get_conda_bld_path,
+    maybe_existing_dir,
+)
 from .install import install_into_conda_bld
 from .testenv import PackageTestSpec, run_package_tests
 
-__all__ = ["build_main"]
+__all__ = ["build_main", "predict_package_path"]
 
 logger = logging.getLogger(__name__)
+
+
+def predict_package_path(
+    rendered: RenderedRecipe,
+    conda_bld_path: Path,
+    package_format: CondaPackageFormat,
+) -> Path:
+    """Predict the file path of the package built from a rendered recipe.
+
+    Uses the same name normalization and build string generation as the
+    wheel converter, so the prediction matches the actual output.
+
+    Args:
+        rendered: the rendered recipe
+        conda_bld_path: conda-bld (or output) directory containing the
+            `noarch/` subdirectory the package lands in
+        package_format: the conda package format
+
+    Raises:
+        RecipeError: if the recipe does not build a noarch python package.
+    """
+    if not rendered.noarch_python:
+        raise RecipeError(
+            f"Cannot predict package path for recipe in {rendered.recipe_dir}:"
+            " it does not build a `noarch: python` package"
+        )
+    name = normalize_pypi_name(rendered.name)
+    build_string = noarch_build_string(rendered.build_number)
+    suffix = str(package_format.value)
+    return (
+        conda_bld_path / "noarch" / f"{name}-{rendered.version}-{build_string}{suffix}"
+    )
 
 
 @dataclasses.dataclass(slots=True)
@@ -53,6 +96,7 @@ class BuildArgs:
     recipe_path: list[Path]
     build_only: bool
     channels: list[str]
+    check: bool
     croot: Path | None
     debug: bool
     extra_deps: list[str]
@@ -210,6 +254,14 @@ def _create_argparser(prog: str | None = None) -> argparse.ArgumentParser:
         help="Print the path of the output package without building.",
     )
     mode_opts.add_argument(
+        "--check",
+        action="store_true",
+        help=dedent("""
+            Only render the recipe and verify that whl2conda can build
+            it, without building anything. (whl2conda extension)
+            """),
+    )
+    mode_opts.add_argument(
         "-t",
         "--test",
         dest="test_only",
@@ -341,15 +393,6 @@ def build_main(
     if len(buildargs.recipe_path) > 1:
         parser.error("only one recipe path is supported")
 
-    # implemented with the render-only support (issue #110)
-    for flag, value in [
-        ("--output", buildargs.output),
-        ("-t/--test", buildargs.test_only),
-        ("--skip-existing", buildargs.skip_existing),
-    ]:
-        if value:
-            parser.error(f"{flag} is not yet supported")
-
     verbosity = (1 if buildargs.debug else 0) - buildargs.quiet
     if verbosity < -1:
         level = logging.ERROR
@@ -392,9 +435,31 @@ class CondaBuild:
             self.work_dir = Path(tempfile.mkdtemp(prefix="whl2conda-build-"))
             rendered = render_recipe(self.recipe_path, self.work_dir)
 
+            if self.args.output:
+                print(self._package_path(rendered))
+                return
+
+            if self.args.test_only:
+                pkg_path = self._package_path(rendered)
+                if not pkg_path.is_file():
+                    raise RecipeError(
+                        f"No package to test at {pkg_path} - build it first"
+                    )
+                self._run_package_tests(pkg_path, rendered)
+                return
+
+            if self.args.skip_existing:
+                pkg_path = self._package_path(rendered)
+                if pkg_path.is_file():
+                    logger.info("Skipping existing package %s", pkg_path)
+                    return
+
             dist_dir = self.work_dir / "dist"
             dist_dir.mkdir()
             self.build_script = rewrite_build_script(rendered, dist_dir)
+            if self.args.check:
+                logger.info("whl2conda can build the recipe in %s", self.recipe_path)
+                return
             wheel = self._build_wheel(dist_dir)
             pkg = self._build_package(wheel, rendered)
             if not (self.args.no_test or self.args.build_only):
@@ -405,6 +470,22 @@ class CondaBuild:
             self._cleanup()
         end = time.time()
         logger.info("Elapsed time: %f seconds", end - start)
+
+    def _package_path(self, rendered: RenderedRecipe) -> Path:
+        """Predict the path of the package built from this recipe.
+
+        This is the path in the output folder, if one was given, and
+        otherwise in the conda-bld directory the package would be
+        installed into.
+        """
+        if self.args.output_folder:
+            bld_path = self.args.output_folder
+        elif self.args.croot:
+            bld_path = self.args.croot
+        else:
+            bld_path = get_conda_bld_path()
+        fmt = self.args.package_format or CondaPackageFormat.V2
+        return predict_package_path(rendered, bld_path, fmt)
 
     def _build_wheel(self, dist_dir: Path) -> Path:
         for line in self.build_script:

--- a/test/api/validator.py
+++ b/test/api/validator.py
@@ -326,24 +326,6 @@ class PackageValidator:
         now_ms = time.time() * 1000
         assert now_ms - 3_600_000 < index["timestamp"] <= now_ms
 
-        if self._is_binary:
-            assert index["arch"] is not None
-            assert index["platform"] is not None
-            assert index["subdir"] != "noarch"
-            if self._is_abi3:
-                # abi3 packages keep platform subdir but use the noarch
-                # python install machinery (CEP-20)
-                assert index["noarch"] == "python"
-                assert re.match(r"py\d+_abi3_\d+", index["build"])
-            else:
-                assert "noarch" not in index
-                assert re.match(r"py\d+_\d+", index["build"])
-        else:
-            assert index["arch"] is None
-            assert index['build'] == 'py_0'
-            assert index["platform"] is None
-            assert index["subdir"] == "noarch"
-
         if self._build_number is not None:
             build_number = self._build_number
         else:
@@ -352,6 +334,24 @@ class PackageValidator:
             except ValueError:
                 build_number = 0
         assert index['build_number'] == build_number
+
+        if self._is_binary:
+            assert index["arch"] is not None
+            assert index["platform"] is not None
+            assert index["subdir"] != "noarch"
+            if self._is_abi3:
+                # abi3 packages keep platform subdir but use the noarch
+                # python install machinery (CEP-20)
+                assert index["noarch"] == "python"
+                assert re.match(rf"py\d+_abi3_{build_number}$", index["build"])
+            else:
+                assert "noarch" not in index
+                assert re.match(rf"py\d+_{build_number}$", index["build"])
+        else:
+            assert index["arch"] is None
+            assert index['build'] == f'py_{build_number}'
+            assert index["platform"] is None
+            assert index["subdir"] == "noarch"
 
         assert index.get("license") == wheel_md.get(
             "license-expression", wheel_md.get("license")

--- a/test/cli/test_build.py
+++ b/test/cli/test_build.py
@@ -431,7 +431,7 @@ def test_build_test_only(
     assert len(fake.test_calls) == 1
     test_call = fake.test_calls[0]
     assert test_call["pkg"] == pkg
-    assert test_call["spec"].imports == ["simple"]
+    assert test_call["spec"].imports == ("simple",)
     assert test_call["source_root"] == recipe_dir
 
 

--- a/test/cli/test_build.py
+++ b/test/cli/test_build.py
@@ -29,9 +29,15 @@ from whl2conda.api.converter import (
     CondaTargetInfo,
     MetadataFromWheel,
     Wheel2CondaConverter,
+    noarch_build_string,
 )
 from whl2conda.cli import main
-from whl2conda.cli.build import _IGNORED_OPTIONS, _UNSUPPORTED_OPTIONS, CondaBuild
+from whl2conda.cli.build import (
+    _IGNORED_OPTIONS,
+    _UNSUPPORTED_OPTIONS,
+    CondaBuild,
+    predict_package_path,
+)
 from whl2conda.impl.recipe import RecipeError, RecipeFormat, RenderedRecipe
 
 RENDERED_RAW: dict[str, Any] = {
@@ -291,6 +297,175 @@ def test_build_wheel_step(
     builder._cleanup()
 
 
+def test_predict_package_path(tmp_path: Path) -> None:
+    """Unit test for predict_package_path"""
+    rendered = RenderedRecipe(
+        format=RecipeFormat.META_YAML,
+        recipe_dir=tmp_path,
+        name="My_Package.name",
+        version="1.2.3",
+        build_number=5,
+        noarch_python=True,
+    )
+    assert (
+        predict_package_path(rendered, tmp_path, CondaPackageFormat.V2)
+        == tmp_path / "noarch" / "my-package-name-1.2.3-py_5.conda"
+    )
+    assert (
+        predict_package_path(rendered, tmp_path, CondaPackageFormat.V1)
+        == tmp_path / "noarch" / "my-package-name-1.2.3-py_5.tar.bz2"
+    )
+
+    # the build string comes from the same helper the converter uses
+    wheel_md = MetadataFromWheel(
+        md={},
+        package_name="my-package-name",
+        version="1.2.3",
+        wheel_build_number="",
+        license=None,
+        dependencies=[],
+        wheel_info_dir=tmp_path,
+        is_pure_python=True,
+        python_tag="py3",
+        abi_tag="none",
+        platform_tag="any",
+    )
+    target = CondaTargetInfo.from_wheel_metadata(wheel_md, build_number=5)
+    assert target.build_string == noarch_build_string(5) == "py_5"
+
+    rendered.noarch_python = False
+    with pytest.raises(RecipeError, match="noarch: python"):
+        predict_package_path(rendered, tmp_path, CondaPackageFormat.V2)
+
+
+def test_build_output_mode(
+    fake_build: tuple[FakeBuild, Path],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """--output prints the predicted package path without building"""
+    fake, recipe_dir = fake_build
+
+    out_folder = tmp_path / "out"
+    main(["build", str(recipe_dir), "--output", "--output-folder", str(out_folder)])
+    out, _err = capsys.readouterr()
+    assert out.strip() == str(out_folder / "noarch" / "simple-1.2.3-py_0.conda")
+    assert fake.converter is None  # nothing was built
+    assert not fake.test_calls
+    assert not fake.install_calls
+
+    # --croot and --package-format are reflected in the prediction
+    croot = tmp_path / "croot"
+    main([
+        "build",
+        str(recipe_dir),
+        "--output",
+        "--croot",
+        str(croot),
+        "--package-format",
+        "tar.bz2",
+    ])
+    out, _err = capsys.readouterr()
+    assert out.strip() == str(croot / "noarch" / "simple-1.2.3-py_0.tar.bz2")
+
+    # defaults to the configured conda-bld directory
+    monkeypatch.setattr(
+        "whl2conda.cli.build.get_conda_bld_path", lambda: tmp_path / "bld"
+    )
+    main(["build", str(recipe_dir), "--output"])
+    out, _err = capsys.readouterr()
+    assert out.strip() == str(tmp_path / "bld" / "noarch" / "simple-1.2.3-py_0.conda")
+
+    # prediction matches where the actual build puts the package
+    main(["build", str(recipe_dir), "--no-test", "--output-folder", str(out_folder)])
+    assert fake.converter is not None
+    actual = Path(fake.converter.out_dir) / "simple-1.2.3-py_0.conda"
+    assert actual == out_folder / "noarch" / "simple-1.2.3-py_0.conda"
+    assert actual.is_file()
+
+
+def test_build_check_mode(
+    fake_build: tuple[FakeBuild, Path],
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """--check renders and validates without building"""
+    fake, recipe_dir = fake_build
+
+    main(["build", str(recipe_dir), "--check"])
+    assert fake.converter is None
+    assert not fake.install_calls
+
+    # a recipe whl2conda cannot build fails the check
+    fake.rendered_raw = {**RENDERED_RAW, "build": {"script": "make install"}}
+    with pytest.raises(SystemExit):
+        main(["build", str(recipe_dir), "--check"])
+    _out, err = capsys.readouterr()
+    assert "does not use" in err
+
+
+def test_build_test_only(
+    fake_build: tuple[FakeBuild, Path],
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """-t/--test tests the already-built package"""
+    fake, recipe_dir = fake_build
+    out_folder = tmp_path / "out"
+    pkg = out_folder / "noarch" / "simple-1.2.3-py_0.conda"
+
+    # package has not been built yet
+    with pytest.raises(SystemExit):
+        main(["build", str(recipe_dir), "-t", "--output-folder", str(out_folder)])
+    _out, err = capsys.readouterr()
+    assert "build it first" in err
+    assert not fake.test_calls
+
+    pkg.parent.mkdir(parents=True)
+    pkg.write_bytes(b"")
+    main(["build", str(recipe_dir), "-t", "--output-folder", str(out_folder)])
+    assert fake.converter is None  # nothing was rebuilt
+    assert not fake.install_calls
+    assert len(fake.test_calls) == 1
+    test_call = fake.test_calls[0]
+    assert test_call["pkg"] == pkg
+    assert test_call["spec"].imports == ["simple"]
+    assert test_call["source_root"] == recipe_dir
+
+
+def test_build_skip_existing(
+    fake_build: tuple[FakeBuild, Path],
+    tmp_path: Path,
+) -> None:
+    """--skip-existing short-circuits when the package exists"""
+    fake, recipe_dir = fake_build
+    out_folder = tmp_path / "out"
+
+    # package does not exist: build proceeds
+    main([
+        "build",
+        str(recipe_dir),
+        "--skip-existing",
+        "--output-folder",
+        str(out_folder),
+    ])
+    assert fake.converter is not None
+    assert len(fake.test_calls) == 1
+
+    # package now exists: build is skipped
+    fake.converter = None
+    fake.test_calls.clear()
+    main([
+        "build",
+        str(recipe_dir),
+        "--skip-existing",
+        "--output-folder",
+        str(out_folder),
+    ])
+    assert fake.converter is None
+    assert not fake.test_calls
+
+
 def test_build_mode_conflicts(
     fake_build: tuple[FakeBuild, Path],
     capsys: pytest.CaptureFixture,
@@ -299,7 +474,9 @@ def test_build_mode_conflicts(
     _fake, recipe_dir = fake_build
     for combo in [
         ["--output", "-b"],
+        ["--check", "--output"],
         ["-t", "--no-test"],
+        ["-t", "--check"],
         ["-b", "--no-test"],
     ]:
         with pytest.raises(SystemExit):
@@ -322,12 +499,6 @@ def test_build_errors(
         main(["build", str(recipe_dir), str(recipe_dir2)])
     _out, err = capsys.readouterr()
     assert "only one recipe path" in err
-
-    for flag in ["--output", "-t", "--skip-existing"]:
-        with pytest.raises(SystemExit):
-            main(["build", str(recipe_dir), flag])
-        _out, err = capsys.readouterr()
-        assert "not yet supported" in err
 
     with pytest.raises(SystemExit):
         main(["build", str(recipe_dir), "--package-format", "zip"])

--- a/test/cli/test_testenv.py
+++ b/test/cli/test_testenv.py
@@ -258,6 +258,7 @@ def test_build_test_adapter(
             "recipe_path": [tmp_path],
             "build_only": False,
             "channels": ["chan"],
+            "check": False,
             "croot": None,
             "debug": False,
             "extra_deps": [],


### PR DESCRIPTION
Third PR in the `whl2conda build` series (stacked on #212; base will be retargeted once it merges).

Completes the remaining #110 modes that were stubbed as "not yet supported" in #212:

- **`--output`** prints the predicted output package path without building. The prediction accounts for `--output-folder`, `--croot`, and `--package-format`, defaulting to the configured conda-bld directory.
- **`-t`/`--test`** runs the recipe's tests against the already-built package (clear error directing you to build first if it doesn't exist).
- **`--skip-existing`** short-circuits the build when the target package already exists.
- **`--check`** (whl2conda extension) renders the recipe and verifies whl2conda can build it — useful for quickly assessing whether an existing recipe fits the whl2conda build model.

All of these derive the package path via the new `predict_package_path()`, which reuses the converter's own `normalize_pypi_name()` and the newly extracted `noarch_build_string()` helper, so predictions and actual artifacts agree by construction.

**Bug fix:** the converter previously hardcoded the noarch build string to `py_0`, ignoring the build number; it now generates `py_<build_number>` (matching conda-build). The package validator now cross-checks the build string against the build number for all package types.

## Testing

- Unit test for `predict_package_path` (name normalization, both formats, non-noarch rejection) plus a consistency check tying `CondaTargetInfo.from_wheel_metadata` to `noarch_build_string`.
- Mode tests in the whitebox harness: `--output` (all three output-directory sources, no side effects, prediction-equals-actual), `--check` (pass and fail), `-t` (missing-package error and test-only flow), `--skip-existing` (both directions), and new mutex-conflict combinations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)