### PR TITLE
Support v1 (recipe.yaml) recipes in whl2conda build (#160)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 ### Features
 
+* `whl2conda build` now supports v1 (`recipe.yaml`) recipes, as built
+  by rattler-build, in addition to classic (`meta.yaml`) recipes.
+  v1 recipes are rendered with the py-rattler-build python package
+  when it is importable and otherwise with the `rattler-build` command;
+  the recipe's `tests:` list is run against the generated package
+  (in a single shared test environment). v1 recipes must declare
+  `noarch: python`. (#160)
+* `whl2conda build` now runs the recipe build script in the recipe's
+  source directory (conda-build's source work directory when populated,
+  otherwise the recipe's local `path:` source), instead of the current
+  directory, so it no longer needs to be invoked from the project root.
+* New "Building from Recipes" user guide documentation page.
 * `whl2conda build` now supports the render-only and test-only
   `conda build` modes: `--output` prints the predicted package path
   without building, `-t`/`--test` runs the recipe tests against the

--- a/doc/guide/building.md
+++ b/doc/guide/building.md
@@ -19,7 +19,8 @@ Instead of solving and creating build/host/test environments, whl2conda:
 Because there is no build environment, this is much faster than
 `conda build`, but it only works for recipes that:
 
-* build a pure python (`noarch: python`) package,
+* build a pure python (`noarch: python`) package
+  (see [#216] for planned binary package support),
 * whose build script consists of a single `pip install .` or
   `pip wheel .` command (extra pip options are fine), and
 * produce a single output package.
@@ -127,6 +128,7 @@ fresh conda environment created with `whl2conda install`:
   test environment, unlike rattler-build, which creates a separate
   environment per element.
 
+[#216]: https://github.com/zuzukin/whl2conda/issues/216
 [conda-build]: https://docs.conda.io/projects/conda-build/
 [rattler-build]: https://rattler.build/
 [py-rattler-build]: https://pypi.org/project/py-rattler-build/

--- a/doc/guide/building.md
+++ b/doc/guide/building.md
@@ -1,0 +1,135 @@
+# Building from Recipes
+
+The `whl2conda build` command is a limited drop-in replacement for
+`conda build` (and, for v1 recipes, `rattler-build build`) that builds
+a conda package from an existing recipe without creating any build
+environments. It is primarily intended to make it easy to evaluate
+whl2conda against a project's existing recipe: run both tools on the
+same recipe and compare the resulting packages.
+
+Instead of solving and creating build/host/test environments, whl2conda:
+
+1. renders the recipe (using conda-build or rattler-build),
+2. runs the recipe's `pip install .` build script as a
+   [pip wheel][pip-wheel] build in the current environment,
+3. converts the resulting wheel directly into a conda package, and
+4. runs the recipe's tests against the package in a fresh conda
+   environment.
+
+Because there is no build environment, this is much faster than
+`conda build`, but it only works for recipes that:
+
+* build a pure python (`noarch: python`) package,
+* whose build script consists of a single `pip install .` or
+  `pip wheel .` command (extra pip options are fine), and
+* produce a single output package.
+
+## Supported recipe formats
+
+Both recipe formats are supported. The format is detected from the
+file in the recipe directory:
+
+* **`meta.yaml`** — classic conda-build recipes. Rendering requires
+  [conda-build], which is used in-process when it is installed in the
+  current environment and is otherwise run in the conda `base`
+  environment.
+
+* **`recipe.yaml`** — v1 recipes ([CEP 13]/[CEP 14]), as built by
+  [rattler-build]. Rendering requires either the [py-rattler-build]
+  python package or the `rattler-build` command on the PATH.
+  v1 recipes must declare `noarch: python`.
+
+## Basic usage
+
+```bash
+$ whl2conda build path/to/recipe/
+```
+
+By default this builds the package, runs the recipe's tests in a fresh
+conda environment, and installs the result into your local conda-bld
+directory (like `conda build`). Some useful options:
+
+```bash
+# write the package to a directory instead of conda-bld
+$ whl2conda build recipe/ --output-folder dist/
+
+# check whether whl2conda can build a recipe, without building
+$ whl2conda build recipe/ --check
+
+# print the output package path without building
+$ whl2conda build recipe/ --output
+
+# test the previously built package
+$ whl2conda build recipe/ -t
+
+# build without testing / without installing
+$ whl2conda build recipe/ --no-test
+$ whl2conda build recipe/ -b
+```
+
+Run `whl2conda build --help` or see the
+[command reference](../reference/cli/whl2conda-build.md) for the full
+option list.
+
+## conda build option compatibility
+
+`whl2conda build` accepts most `conda build` options so that it can be
+dropped into existing scripts:
+
+* Options that map onto whl2conda's build model are honored:
+  `-c`/`--channel`, `--output-folder`, `--package-format`, `--croot`,
+  `--python`, `--skip-existing`, `-q`/`--quiet`, `--debug`, `-t`,
+  `-b`/`--build-only`, `--no-test`, and `--output`.
+
+* Options that do not apply to this build model (e.g.
+  `--variant-config-files`, `--numpy`, `--dirty`) are accepted and
+  ignored with a warning.
+
+* Options whose omission would silently change the meaning of a build
+  pipeline — package uploading/signing options and non-python language
+  support (`--perl`, `--R`, `--lua`) — are rejected with an error.
+
+There are also a few whl2conda extensions: `--check` (validate the
+recipe without building), `--extra-deps` (additional conda
+dependencies), and `--keep-test-env` (keep the test environment for
+debugging).
+
+## Evaluating whl2conda against your recipe
+
+To assess whether whl2conda produces an acceptable package for your
+project, build the same recipe with both tools and compare the results
+with [whl2conda diff](testing.md):
+
+```bash
+$ conda build my-recipe/ --output-folder conda-build-out/
+$ whl2conda build my-recipe/ --output-folder whl2conda-out/
+$ whl2conda diff conda-build-out/noarch/mypkg-1.2.3-py_0.conda \
+    whl2conda-out/noarch/mypkg-1.2.3-py_0.conda
+```
+
+The diff analysis reports notable and unexpected differences while
+suppressing differences that are expected between whl2conda-generated
+and recipe-built packages.
+
+## Package tests
+
+The recipe's test section is run against the generated package in a
+fresh conda environment created with `whl2conda install`:
+
+* For `meta.yaml` recipes, the `test:` section's `requires`,
+  `imports`, `commands`, and `source_files` entries are honored.
+
+* For `recipe.yaml` recipes, the `tests:` list's `python` elements
+  (`imports`, `pip_check`) and `script` elements (with
+  `requirements.run` and `files.source`) are honored;
+  `package_contents` and `downstream` elements are ignored with a
+  warning. Note that whl2conda runs all test elements in a single
+  test environment, unlike rattler-build, which creates a separate
+  environment per element.
+
+[conda-build]: https://docs.conda.io/projects/conda-build/
+[rattler-build]: https://rattler.build/
+[py-rattler-build]: https://pypi.org/project/py-rattler-build/
+[CEP 13]: https://github.com/conda/ceps/blob/main/cep-0013.md
+[CEP 14]: https://github.com/conda/ceps/blob/main/cep-0014.md
+[pip-wheel]: https://pip.pypa.io/en/stable/cli/pip_wheel/

--- a/doc/reference/links.md
+++ b/doc/reference/links.md
@@ -6,6 +6,10 @@
 * [CEP-20](https://conda.org/learn/ceps/cep-0020/) - support for abi3 python packages
 * [conda-package-handling tool (cph)](https://conda.github.io/conda-package-handling/)
 * [conda-build](https://docs.conda.io/projects/conda-build/)
+* [rattler-build](https://rattler.build/)
+* [py-rattler-build](https://pypi.org/project/py-rattler-build/) - python bindings for rattler-build
+* [CEP-13](https://github.com/conda/ceps/blob/main/cep-0013.md) - v1 recipe format
+* [CEP-14](https://github.com/conda/ceps/blob/main/cep-0014.md) - v1 recipe schema
 
 ## Wheels:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,9 @@ packaging = ">=23"
 pyright = ">=1.1,<2.0"
 pytest = ">=7.4,<8.0"
 pytest-cov = ">=4.1.0,<5.0"
+# for whl2conda build v1 recipe rendering (external tests)
+py-rattler-build = ">=0.40"
+rattler-build = ">=0.40"
 ruff = ">=0.3.7"
 types-pyyaml = ">=6.0"
 

--- a/src/whl2conda/cli/build.py
+++ b/src/whl2conda/cli/build.py
@@ -38,6 +38,7 @@ from ..api.converter import (
 # this project
 from ..impl.recipe import (
     RecipeError,
+    RecipeFormat,
     RenderedRecipe,
     render_recipe,
     rewrite_build_script,
@@ -216,21 +217,20 @@ def _create_argparser(prog: str | None = None) -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         usage="%(prog)s <recipe-path> [options]",
         description=dedent("""
-            Build a conda package from a pure python wheel.
+            Build a conda package from an existing conda recipe.
 
             This command is a limited drop-in replacement for `conda build`
-            for recipes of pure python packages whose build script is a
-            `pip install .` or `pip wheel .` command: it builds the wheel
-            and converts it directly to a conda package without creating
-            a build environment.
+            (and rattler-build) for recipes of pure python packages whose
+            build script is a `pip install .` or `pip wheel .` command:
+            it builds the wheel and converts it directly to a conda
+            package without creating a build environment. Both classic
+            (meta.yaml) and v1 (recipe.yaml) recipes are supported;
+            v1 recipes must declare `noarch: python`.
 
             Most conda build options that do not apply to this build
             model are accepted and ignored with a warning; options whose
             omission would silently change the meaning of a build
             pipeline (e.g. package uploads) are rejected with an error.
-
-            This is an experimental feature and is still under active
-            change and development.
             """),
         formatter_class=argparse.RawTextHelpFormatter,
         prog=prog,
@@ -460,7 +460,7 @@ class CondaBuild:
             if self.args.check:
                 logger.info("whl2conda can build the recipe in %s", self.recipe_path)
                 return
-            wheel = self._build_wheel(dist_dir)
+            wheel = self._build_wheel(dist_dir, self._source_root(rendered))
             pkg = self._build_package(wheel, rendered)
             if not (self.args.no_test or self.args.build_only):
                 self._run_package_tests(pkg, rendered)
@@ -487,9 +487,31 @@ class CondaBuild:
         fmt = self.args.package_format or CondaPackageFormat.V2
         return predict_package_path(rendered, bld_path, fmt)
 
-    def _build_wheel(self, dist_dir: Path) -> Path:
+    def _source_root(self, rendered: RenderedRecipe) -> Path:
+        """Directory containing the project source for this recipe.
+
+        This is the source copy in conda-build's work directory when it
+        exists, otherwise the recipe's local `path:` source when it has
+        one, and otherwise the current directory.
+        """
+        for work_src in sorted(self.work_dir.glob("croot/*/work")):
+            # conda-build only populates the work dir when the recipe
+            # needs the source at render time
+            if any(work_src.iterdir()):
+                return work_src
+        sources = rendered.raw.get("source") or ()
+        if isinstance(sources, dict):
+            sources = (sources,)
+        for source in sources:
+            if isinstance(source, dict) and (path := source.get("path")):
+                source_root = (rendered.recipe_dir / str(path)).resolve()
+                if source_root.is_dir():
+                    return source_root
+        return Path.cwd()
+
+    def _build_wheel(self, dist_dir: Path, source_root: Path) -> Path:
         for line in self.build_script:
-            subprocess.check_call(line, shell=True)
+            subprocess.check_call(line, shell=True, cwd=source_root)
         try:
             return next(dist_dir.glob("*.whl"))
         except StopIteration:
@@ -514,21 +536,18 @@ class CondaBuild:
         return pkg
 
     def _run_package_tests(self, pkg: Path, rendered: RenderedRecipe) -> None:
-        spec = PackageTestSpec.from_meta_yaml(rendered.raw.get("test") or {})
+        if rendered.format is RecipeFormat.V1:
+            spec = PackageTestSpec.from_v1_tests(rendered.raw.get("tests") or ())
+        else:
+            spec = PackageTestSpec.from_meta_yaml(rendered.raw.get("test") or {})
         if not spec:
             return
-        # conda-build's render copies the source tree into its work dir,
-        # from which test source_files are resolved
-        source_root = self.recipe_path
-        for work_src in sorted(self.work_dir.glob("croot/*/work")):
-            source_root = work_src
-            break
         run_package_tests(
             pkg,
             spec,
             env_prefix=self.work_dir / "test-env",
             work_dir=self.work_dir / "test_tmp",
-            source_root=source_root,
+            source_root=self._source_root(rendered),
             channels=self.args.channels,
             keep_env=self.args.keep_test_env,
         )

--- a/src/whl2conda/cli/build.py
+++ b/src/whl2conda/cli/build.py
@@ -81,6 +81,7 @@ def predict_package_path(
         raise RecipeError(
             f"Cannot predict package path for recipe in {rendered.recipe_dir}:"
             " it does not build a `noarch: python` package"
+            " (see https://github.com/zuzukin/whl2conda/issues/216)"
         )
     name = normalize_pypi_name(rendered.name)
     build_string = noarch_build_string(rendered.build_number)

--- a/src/whl2conda/impl/recipe.py
+++ b/src/whl2conda/impl/recipe.py
@@ -170,6 +170,7 @@ def _normalize_v1(raw: Mapping[str, Any], recipe_dir: Path) -> RenderedRecipe:
         raise RecipeError(
             f"Cannot build from v1 recipe in {recipe_dir}: whl2conda build"
             " only supports v1 recipes with `noarch: python`"
+            " (see https://github.com/zuzukin/whl2conda/issues/216)"
         )
     return RenderedRecipe(
         format=RecipeFormat.V1,

--- a/src/whl2conda/impl/recipe.py
+++ b/src/whl2conda/impl/recipe.py
@@ -15,9 +15,9 @@
 Conda recipe reading and rendering for `whl2conda build`.
 
 Supports classic conda recipes (meta.yaml, rendered through conda-build)
-and, in the future, v1 recipes (recipe.yaml, rendered through
-rattler-build). Rendered recipes of both formats are normalized into a
-common [RenderedRecipe][(m).] structure containing just what
+and v1 recipes (recipe.yaml, rendered through rattler-build). Rendered
+recipes of both formats are normalized into a common
+[RenderedRecipe][(m).] structure containing just what
 `whl2conda build` needs.
 """
 
@@ -26,7 +26,7 @@ from __future__ import annotations
 # standard
 import enum
 import re
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -126,10 +126,10 @@ def render_recipe(
     """
     recipe_file, recipe_format = find_recipe_file(recipe_dir)
     if recipe_format is RecipeFormat.V1:
-        # implemented with #160
-        raise RecipeError(
-            f"v1 recipes are not yet supported by whl2conda build: {recipe_file}"
-        )
+        from .render_v1 import render_v1_yaml
+
+        raw = render_v1_yaml(recipe_file)
+        return _normalize_v1(raw, recipe_dir)
 
     # local import so that recipe.py has no yaml dependency at import time
     from .render_meta import render_meta_yaml
@@ -142,23 +142,64 @@ def _normalize_meta_yaml(raw: dict[str, Any], recipe_dir: Path) -> RenderedRecip
     """Normalize a rendered meta.yaml document."""
     package = raw.get("package") or {}
     build = raw.get("build") or {}
-    script = build.get("script") or []
-    if isinstance(script, str):
-        script = [script]
-    try:
-        build_number = int(build.get("number") or 0)
-    except (TypeError, ValueError):
-        build_number = 0
     return RenderedRecipe(
         format=RecipeFormat.META_YAML,
         recipe_dir=recipe_dir,
         name=str(package.get("name") or ""),
         version=str(package.get("version") or ""),
-        build_number=build_number,
-        build_script=[str(line) for line in script],
+        build_number=_build_number(build),
+        build_script=_script_lines(build.get("script")),
         noarch_python=build.get("noarch") == "python",
         raw=raw,
     )
+
+
+def _normalize_v1(raw: dict[str, Any], recipe_dir: Path) -> RenderedRecipe:
+    """Normalize a rendered v1 recipe.yaml document.
+
+    Raises:
+        RecipeError: if the recipe does not build a `noarch: python`
+            package.
+    """
+    package = raw.get("package") or {}
+    build = raw.get("build") or {}
+    if build.get("noarch") != "python":
+        raise RecipeError(
+            f"Cannot build from v1 recipe in {recipe_dir}: whl2conda build"
+            " only supports v1 recipes with `noarch: python`"
+        )
+    return RenderedRecipe(
+        format=RecipeFormat.V1,
+        recipe_dir=recipe_dir,
+        name=str(package.get("name") or ""),
+        version=str(package.get("version") or ""),
+        build_number=_build_number(build),
+        build_script=_script_lines(build.get("script")),
+        noarch_python=True,
+        raw=raw,
+    )
+
+
+def _build_number(build: Mapping[str, Any]) -> int:
+    try:
+        return int(build.get("number") or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _script_lines(script: Any) -> list[str]:
+    """Normalize a recipe build script into a list of lines.
+
+    Handles a single string, a list of lines, and the v1 object form
+    with a `content` key.
+    """
+    if isinstance(script, Mapping):
+        script = script.get("content") or []
+    if script is None:
+        script = []
+    elif isinstance(script, str):
+        script = [script]
+    return [str(line) for line in script]
 
 
 #: Matches a `pip install .` or `pip wheel .` line, possibly prefixed

--- a/src/whl2conda/impl/render_meta.py
+++ b/src/whl2conda/impl/render_meta.py
@@ -23,7 +23,9 @@ into a whl2conda-controlled work directory.
 from __future__ import annotations
 
 # standard
+import contextlib
 import importlib.util
+import io
 import logging
 import subprocess
 from pathlib import Path
@@ -87,16 +89,23 @@ def _render_in_process(recipe_dir: Path, croot: Path, out_file: Path) -> None:
     # conda-build is an optional runtime dependency, not installed here
     import conda_build.api as api  # type: ignore[import-untyped,import-not-found]
 
+    # conda-build prints progress chatter directly to stdout, which
+    # would corrupt output-sensitive modes like `whl2conda build --output`
+    chatter = io.StringIO()
     try:
-        config = api.Config(croot=str(croot))
-        mds = api.render(str(recipe_dir), config=config, bypass_env_check=True)
-        if len(mds) > 1:
-            logger.warning("Recipe has multiple variants; using the first")
-        api.output_yaml(mds[0][0], file_path=str(out_file))
+        with contextlib.redirect_stdout(chatter):
+            config = api.Config(croot=str(croot))
+            mds = api.render(str(recipe_dir), config=config, bypass_env_check=True)
+            if len(mds) > 1:
+                logger.warning("Recipe has multiple variants; using the first")
+            api.output_yaml(mds[0][0], file_path=str(out_file))
     except Exception as ex:
         raise RecipeRenderError(
             f"conda-build failed to render {recipe_dir}: {ex}"
         ) from ex
+    finally:
+        if output := chatter.getvalue():
+            logger.debug("conda-build render output:\n%s", output)
 
 
 def _render_in_base_env(recipe_dir: Path, croot: Path, out_file: Path) -> None:

--- a/src/whl2conda/impl/render_v1.py
+++ b/src/whl2conda/impl/render_v1.py
@@ -1,0 +1,128 @@
+#  Copyright 2026 Christopher Barber
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Render v1 conda recipes (recipe.yaml) using rattler-build.
+
+Uses the py-rattler-build python bindings when they are importable in
+the current environment, and otherwise runs the `rattler-build`
+executable in render-only mode. Neither is a runtime dependency of
+whl2conda; a clear error is raised if both are missing.
+"""
+
+from __future__ import annotations
+
+# standard
+import importlib.util
+import json
+import logging
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+# this project
+from .recipe import RecipeError, RecipeRenderError
+
+__all__ = ["render_v1_yaml"]
+
+logger = logging.getLogger(__name__)
+
+
+def render_v1_yaml(recipe_file: Path) -> dict[str, Any]:
+    """Render a v1 recipe.yaml recipe using rattler-build.
+
+    Args:
+        recipe_file: the recipe.yaml file
+
+    Returns:
+        The rendered recipe as a dictionary.
+
+    Raises:
+        RecipeError: if no rattler-build tooling is available or the
+            recipe renders to more than one output.
+        RecipeRenderError: if rendering fails.
+    """
+    raw = _render_in_process(recipe_file)
+    if raw is None:
+        raw = _render_with_cli(recipe_file)
+    return raw
+
+
+def _render_in_process(recipe_file: Path) -> dict[str, Any] | None:
+    """Render using py-rattler-build, or return None if unavailable."""
+    if importlib.util.find_spec("rattler_build") is None:
+        return None
+    import rattler_build  # type: ignore[import-untyped,import-not-found]
+
+    if not hasattr(rattler_build, "Stage0Recipe"):
+        # unexpected python binding version - fall back to the executable
+        return None
+    logger.debug("Rendering %s with py-rattler-build", recipe_file)
+
+    try:
+        recipe = rattler_build.Stage0Recipe.from_file(str(recipe_file))
+    except Exception as ex:
+        raise RecipeRenderError(
+            f"rattler-build cannot parse {recipe_file}: {ex}"
+        ) from ex
+    try:
+        recipe.as_single_output()
+    except TypeError:
+        raise _multiple_outputs_error(recipe_file) from None
+    try:
+        variants = recipe.render()
+    except Exception as ex:
+        raise RecipeRenderError(
+            f"rattler-build failed to render {recipe_file}: {ex}"
+        ) from ex
+    if len(variants) != 1:
+        raise _multiple_outputs_error(recipe_file)
+    return variants[0].recipe.to_dict()
+
+
+def _render_with_cli(recipe_file: Path) -> dict[str, Any]:
+    """Render by running the rattler-build executable."""
+    exe = shutil.which("rattler-build")
+    if exe is None:
+        raise RecipeError(
+            f"Cannot render {recipe_file}: v1 recipe support requires either"
+            " the py-rattler-build python package or the rattler-build"
+            " command on the PATH"
+        )
+    logger.debug("Rendering %s with %s", recipe_file, exe)
+
+    cmd = [exe, "build", "--render-only", "--recipe", str(recipe_file)]
+    result = subprocess.run(cmd, capture_output=True, encoding="utf8", check=False)
+    if result.returncode != 0:
+        stderr_tail = "\n".join(result.stderr.splitlines()[-15:])
+        raise RecipeRenderError(
+            f"rattler-build failed to render {recipe_file}"
+            f" (exit status {result.returncode}):\n{stderr_tail}"
+        )
+    try:
+        outputs = json.loads(result.stdout)
+    except json.JSONDecodeError as ex:
+        raise RecipeRenderError(
+            f"Cannot parse rattler-build render output for {recipe_file}: {ex}"
+        ) from ex
+    if not isinstance(outputs, list) or len(outputs) != 1:
+        raise _multiple_outputs_error(recipe_file)
+    return outputs[0]["recipe"]
+
+
+def _multiple_outputs_error(recipe_file: Path) -> RecipeError:
+    return RecipeError(
+        f"Recipe {recipe_file} renders to multiple outputs or variants,"
+        " which is not supported by whl2conda build"
+    )

--- a/src/whl2conda/impl/render_v1.py
+++ b/src/whl2conda/impl/render_v1.py
@@ -63,7 +63,7 @@ def _render_in_process(recipe_file: Path) -> dict[str, Any] | None:
     """Render using py-rattler-build, or return None if unavailable."""
     if importlib.util.find_spec("rattler_build") is None:
         return None
-    import rattler_build  # type: ignore[import-untyped,import-not-found]  # noqa: PLC0415
+    import rattler_build  # type: ignore # noqa: PLC0415
 
     if not hasattr(rattler_build, "Stage0Recipe"):
         # unexpected python binding version - fall back to the executable

--- a/test-projects/recipe/hello/__init__.py
+++ b/test-projects/recipe/hello/__init__.py
@@ -1,0 +1,6 @@
+"""whl2conda build test fixture package"""
+
+
+def greeting() -> str:
+    """Returns a friendly greeting"""
+    return "hello"

--- a/test-projects/recipe/pyproject.toml
+++ b/test-projects/recipe/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "hello"
+version = "1.0.0"
+description = "whl2conda build test fixture"
+license = { text = "MIT" }
+requires-python = ">=3.9"
+
+[tool.hatch.build.targets.wheel]
+packages = ["hello"]

--- a/test-projects/recipe/recipe-meta/meta.yaml
+++ b/test-projects/recipe/recipe-meta/meta.yaml
@@ -1,0 +1,38 @@
+# Classic conda recipe for the whl2conda build test fixture.
+# Equivalent to the v1 recipe in ../recipe-v1/recipe.yaml.
+
+{% set version = "1.0.0" %}
+
+package:
+  name: hello
+  version: {{ version }}
+
+source:
+  path: ../
+
+build:
+  noarch: python
+  number: 1
+  script: pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python
+    - pip
+    - hatchling
+  run:
+    - python >=3.9
+
+test:
+  source_files:
+    - test
+  requires:
+    - pytest
+  imports:
+    - hello
+  commands:
+    - pytest test
+
+about:
+  summary: whl2conda build test fixture
+  license: MIT

--- a/test-projects/recipe/recipe-v1/recipe.yaml
+++ b/test-projects/recipe/recipe-v1/recipe.yaml
@@ -1,0 +1,44 @@
+# v1 conda recipe for the whl2conda build test fixture.
+# Equivalent to the classic recipe in ../recipe-meta/meta.yaml.
+
+context:
+  name: hello
+  version: "1.0.0"
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  path: ../
+
+build:
+  number: 1
+  noarch: python
+  script: pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python
+    - pip
+    - hatchling
+  run:
+    - python >=3.9
+
+tests:
+  - python:
+      imports:
+        - hello
+      pip_check: false
+  - script:
+      - pytest test
+    requirements:
+      run:
+        - pytest
+    files:
+      source:
+        - test/
+
+about:
+  summary: whl2conda build test fixture
+  license: MIT

--- a/test-projects/recipe/test/test_hello.py
+++ b/test-projects/recipe/test/test_hello.py
@@ -1,0 +1,5 @@
+from hello import greeting
+
+
+def test_greeting() -> None:
+    assert greeting() == "hello"

--- a/test/cli/test_build.py
+++ b/test/cli/test_build.py
@@ -321,9 +321,9 @@ def test_build_v1_tests(fake_build: tuple[FakeBuild, Path]) -> None:
     main(["build", str(recipe_dir)])
     assert len(fake.test_calls) == 1
     spec = fake.test_calls[0]["spec"]
-    assert spec.imports == ["simple"]
-    assert spec.commands == ["pytest test"]
-    assert spec.requires == ["pytest"]
+    assert spec.imports == ("simple",)
+    assert spec.commands == ("pytest test",)
+    assert spec.requires == ("pytest",)
     assert not spec.pip_check
     assert fake.test_calls[0]["source_root"] == recipe_dir
 

--- a/test/cli/test_build.py
+++ b/test/cli/test_build.py
@@ -42,6 +42,7 @@ from whl2conda.impl.recipe import RecipeError, RecipeFormat, RenderedRecipe
 
 RENDERED_RAW: dict[str, Any] = {
     "package": {"name": "simple", "version": "1.2.3"},
+    "source": [{"path": "."}],
     "build": {"noarch": "python", "number": 0, "script": "pip install ."},
     "test": {"imports": ["simple"]},
 }
@@ -56,6 +57,7 @@ class FakeBuild:
         self.test_calls: list[dict[str, Any]] = []
         self.install_calls: list[tuple[list[Path], str, dict[str, Any]]] = []
         self.rendered_raw: dict[str, Any] = dict(RENDERED_RAW)
+        self.rendered_format = RecipeFormat.META_YAML
 
         fake = self
 
@@ -66,7 +68,7 @@ class FakeBuild:
             if isinstance(script, str):
                 script = [script]
             return RenderedRecipe(
-                format=RecipeFormat.META_YAML,
+                format=fake.rendered_format,
                 recipe_dir=recipe_dir,
                 name=raw["package"]["name"],
                 version=raw["package"]["version"],
@@ -76,7 +78,9 @@ class FakeBuild:
                 raw=raw,
             )
 
-        def fake_build_wheel(builder: CondaBuild, dist_dir: Path) -> Path:
+        def fake_build_wheel(
+            builder: CondaBuild, dist_dir: Path, source_root: Path
+        ) -> Path:
             wheel = dist_dir / "simple-1.2.3-py3-none-any.whl"
             wheel.parent.mkdir(parents=True, exist_ok=True)
             wheel.write_bytes(b"")
@@ -261,8 +265,9 @@ def test_build_wheel_step(
     dist_dir = tmp_path / "dist"
     dist_dir.mkdir()
 
-    def fake_check_call(cmd, shell=False) -> None:
+    def fake_check_call(cmd, shell=False, cwd=None) -> None:
         assert shell is True
+        assert cwd == recipe_dir
         commands.append(cmd)
 
     monkeypatch.setattr("whl2conda.cli.build.subprocess.check_call", fake_check_call)
@@ -285,16 +290,46 @@ def test_build_wheel_step(
 
     # build script ran but produced no wheel
     with pytest.raises(RecipeError, match="did not produce a wheel"):
-        builder._build_wheel(dist_dir)
+        builder._build_wheel(dist_dir, recipe_dir)
     assert commands == [f"pip wheel . -w {dist_dir}"]
 
     wheel = dist_dir / "simple-1.2.3-py3-none-any.whl"
     wheel.write_bytes(b"")
-    assert builder._build_wheel(dist_dir) == wheel
+    assert builder._build_wheel(dist_dir, recipe_dir) == wheel
 
     # cleanup tolerates a work dir that was never created
     assert not builder.work_dir.exists()
     builder._cleanup()
+
+
+def test_build_v1_tests(fake_build: tuple[FakeBuild, Path]) -> None:
+    """v1 recipes use the v1 test specification"""
+    fake, recipe_dir = fake_build
+    fake.rendered_format = RecipeFormat.V1
+    fake.rendered_raw = {
+        "package": {"name": "simple", "version": "1.2.3"},
+        "source": [{"path": "."}],
+        "build": {"noarch": "python", "number": 0, "script": "pip install ."},
+        "tests": [
+            {"python": {"imports": ["simple"], "pip_check": False}},
+            {"script": "pytest test", "requirements": {"run": ["pytest"]}},
+        ],
+    }
+
+    main(["build", str(recipe_dir)])
+    assert len(fake.test_calls) == 1
+    spec = fake.test_calls[0]["spec"]
+    assert spec.imports == ["simple"]
+    assert spec.commands == ["pytest test"]
+    assert spec.requires == ["pytest"]
+    assert not spec.pip_check
+    assert fake.test_calls[0]["source_root"] == recipe_dir
+
+    # empty v1 tests: no test run
+    fake.test_calls.clear()
+    fake.rendered_raw = {**fake.rendered_raw, "tests": []}
+    main(["build", str(recipe_dir)])
+    assert not fake.test_calls
 
 
 def test_predict_package_path(tmp_path: Path) -> None:
@@ -557,3 +592,125 @@ def test_build_unsupported_options(
         main(args)
     _out, err = capsys.readouterr()
     assert f"{flags[0]} is not supported" in err
+
+
+#
+# End-to-end tests (external)
+#
+
+this_dir = Path(__file__).parent.absolute()
+root_dir = this_dir.parent.parent
+FIXTURE_PROJECT = root_dir / "test-projects" / "recipe"
+
+
+def _e2e_build(
+    recipe_dir: Path, tmp_path: Path, *extra_args: str, out_name: str = "out"
+) -> Path:
+    """Build fixture recipe into an output folder; returns package path."""
+    out_folder = tmp_path / out_name
+    main([
+        "build",
+        str(recipe_dir),
+        "--output-folder",
+        str(out_folder),
+        "--no-test",
+        *extra_args,
+    ])
+    pkg = out_folder / "noarch" / "hello-1.0.0-py_1.conda"
+    assert pkg.is_file()
+    return pkg
+
+
+@pytest.mark.external
+def test_build_e2e_meta(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """End-to-end build of the classic fixture recipe (no test env)"""
+    pytest.importorskip("conda_build", reason="requires conda-build")
+    recipe_dir = FIXTURE_PROJECT / "recipe-meta"
+
+    # --output prediction matches the built artifact
+    out_folder = tmp_path / "out"
+    main(["build", str(recipe_dir), "--output", "--output-folder", str(out_folder)])
+    out, _err = capsys.readouterr()
+    predicted = Path(out.strip())
+
+    pkg = _e2e_build(recipe_dir, tmp_path)
+    assert pkg == predicted
+
+    # --skip-existing skips the rebuild
+    with caplog.at_level("INFO"):
+        main([
+            "build",
+            str(recipe_dir),
+            "--skip-existing",
+            "--output-folder",
+            str(out_folder),
+        ])
+    assert "Skipping existing package" in caplog.text
+
+    # --check validates without building
+    main(["build", str(recipe_dir), "--check"])
+
+
+@pytest.mark.external
+def test_build_e2e_v1(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """End-to-end build of the v1 fixture recipe (no test env)"""
+    pytest.importorskip("rattler_build", reason="requires py-rattler-build")
+    recipe_dir = FIXTURE_PROJECT / "recipe-v1"
+
+    main([
+        "build",
+        str(recipe_dir),
+        "--output",
+        "--output-folder",
+        str(tmp_path / "out"),
+    ])
+    out, _err = capsys.readouterr()
+    predicted = Path(out.strip())
+
+    pkg = _e2e_build(recipe_dir, tmp_path)
+    assert pkg == predicted
+
+
+@pytest.mark.external
+@pytest.mark.slow
+@pytest.mark.parametrize("recipe_name", ["recipe-meta", "recipe-v1"])
+def test_build_e2e_with_tests(
+    tmp_path: Path,
+    recipe_name: str,
+) -> None:
+    """End-to-end build of fixture recipes including the package tests"""
+    if recipe_name == "recipe-meta":
+        pytest.importorskip("conda_build", reason="requires conda-build")
+    else:
+        pytest.importorskip("rattler_build", reason="requires py-rattler-build")
+    recipe_dir = FIXTURE_PROJECT / recipe_name
+
+    out_folder = tmp_path / "out"
+    main([
+        "build",
+        str(recipe_dir),
+        "--output-folder",
+        str(out_folder),
+        "-c",
+        "conda-forge",
+    ])
+    pkg = out_folder / "noarch" / "hello-1.0.0-py_1.conda"
+    assert pkg.is_file()
+
+    # -t/--test re-tests the built package
+    main([
+        "build",
+        str(recipe_dir),
+        "-t",
+        "--output-folder",
+        str(out_folder),
+        "-c",
+        "conda-forge",
+    ])

--- a/test/cli/test_testenv.py
+++ b/test/cli/test_testenv.py
@@ -17,6 +17,7 @@ Unit tests for whl2conda.cli.testenv
 
 from __future__ import annotations
 
+import shutil
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -312,6 +313,18 @@ def test_build_test_adapter(
     builder._run_package_tests(pkg, rendered)
     assert calls[2]["source_root"] == work_src
 
+    # no work dir and no local path source: falls back to the current dir
+    shutil.rmtree(builder.work_dir / "croot")
+    builder._run_package_tests(pkg, make_rendered({"test": {"imports": ["foo"]}}))
+    assert calls[3]["source_root"] == Path.cwd()
+
+    # single-dict source form (as rendered from meta.yaml)
+    builder._run_package_tests(
+        pkg,
+        make_rendered({"source": {"path": "."}, "test": {"imports": ["foo"]}}),
+    )
+    assert calls[4]["source_root"] == tmp_path
+
     # empty test section: runner is not invoked
     builder._run_package_tests(pkg, make_rendered({}))
-    assert len(calls) == 3
+    assert len(calls) == 5

--- a/test/cli/test_testenv.py
+++ b/test/cli/test_testenv.py
@@ -287,7 +287,10 @@ def test_build_test_adapter(
     builder = CondaBuild(make_args())
     builder.work_dir = tmp_path / "build-work"
     pkg = tmp_path / "foo-1.0-py_0.conda"
-    rendered = make_rendered({"test": {"imports": ["foo"], "source_files": ["test"]}})
+    rendered = make_rendered({
+        "source": [{"path": "."}],
+        "test": {"imports": ["foo"], "source_files": ["test"]},
+    })
 
     builder._run_package_tests(pkg, rendered)
     assert len(calls) == 1
@@ -296,16 +299,19 @@ def test_build_test_adapter(
     assert call["spec"].imports == ["foo"]
     assert call["channels"] == ["chan"]
     assert call["keep_env"] is True
-    # no conda-build work dir: source files resolve from the recipe dir
+    # no conda-build work dir: source files resolve from the path source
     assert call["source_root"] == tmp_path
     assert call["env_prefix"] == builder.work_dir / "test-env"
 
-    # conda-build work dir is preferred when present
+    # a populated conda-build work dir is preferred when present
     work_src = builder.work_dir / "croot" / "foo_123" / "work"
     work_src.mkdir(parents=True)
     builder._run_package_tests(pkg, rendered)
-    assert calls[1]["source_root"] == work_src
+    assert calls[1]["source_root"] == tmp_path  # empty work dir is ignored
+    (work_src / "pyproject.toml").write_text("")
+    builder._run_package_tests(pkg, rendered)
+    assert calls[2]["source_root"] == work_src
 
     # empty test section: runner is not invoked
     builder._run_package_tests(pkg, make_rendered({}))
-    assert len(calls) == 2
+    assert len(calls) == 3

--- a/test/impl/test_recipe.py
+++ b/test/impl/test_recipe.py
@@ -155,6 +155,11 @@ def test_render_recipe_v1(
     assert rendered.build_script == ["echo before", "pip install ."]
     assert rendered.build_number == 0
 
+    # a missing script is normalized to an empty list
+    rendered_raw["build"] = {"noarch": "python"}
+    rendered = render_recipe(recipe_dir, tmp_path / "work")
+    assert rendered.build_script == []
+
     # non-noarch v1 recipes are rejected
     rendered_raw["build"] = {"script": "pip install ."}
     with pytest.raises(RecipeError, match="noarch: python"):
@@ -352,7 +357,9 @@ def test_render_meta_yaml_failure(
 #
 
 
-def _fake_rattler_module(*, multi=False, parse_fail=False, render_fail=False):
+def _fake_rattler_module(
+    *, multi=False, parse_fail=False, render_fail=False, variants=1
+):
     """Create a fake rattler_build module rendering RENDERED_V1."""
     mod = types.ModuleType("rattler_build")
 
@@ -379,7 +386,7 @@ def _fake_rattler_module(*, multi=False, parse_fail=False, render_fail=False):
         def render(self) -> list:
             if render_fail:
                 raise ValueError("render boom")
-            return [FakeRendered()]
+            return [FakeRendered() for _ in range(variants)]
 
     mod.Stage0Recipe = Stage0Recipe  # type: ignore[attr-defined]
     return mod
@@ -405,6 +412,24 @@ def test_render_v1_yaml_in_process(
     monkeypatch.setitem(sys.modules, "rattler_build", _fake_rattler_module(multi=True))
     with pytest.raises(RecipeError, match="multiple outputs"):
         render_v1_yaml(recipe_file)
+
+    # multiple rendered variants are also rejected
+    monkeypatch.setitem(sys.modules, "rattler_build", _fake_rattler_module(variants=2))
+    with pytest.raises(RecipeError, match="multiple outputs"):
+        render_v1_yaml(recipe_file)
+
+    # unexpected binding version (no Stage0Recipe): falls back to the CLI
+    monkeypatch.setitem(sys.modules, "rattler_build", types.ModuleType("rattler_build"))
+    monkeypatch.setattr(
+        "whl2conda.impl.render_v1.shutil.which", lambda _name: "/bin/rattler-build"
+    )
+    monkeypatch.setattr(
+        "whl2conda.impl.render_v1.subprocess.run",
+        lambda cmd, **_kwargs: subprocess.CompletedProcess(
+            cmd, 0, stdout=json.dumps([{"recipe": RENDERED_V1}]), stderr=""
+        ),
+    )
+    assert render_v1_yaml(recipe_file) == RENDERED_V1
 
     monkeypatch.setitem(
         sys.modules, "rattler_build", _fake_rattler_module(parse_fail=True)

--- a/test/impl/test_recipe.py
+++ b/test/impl/test_recipe.py
@@ -17,6 +17,7 @@ Unit tests for whl2conda.impl.recipe and whl2conda.impl.render_meta
 
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
 import types
@@ -36,6 +37,7 @@ from whl2conda.impl.recipe import (
     rewrite_build_script,
 )
 from whl2conda.impl.render_meta import render_meta_yaml
+from whl2conda.impl.render_v1 import render_v1_yaml
 
 RENDERED_META = {
     "package": {"name": "simple", "version": "1.2.3"},
@@ -104,12 +106,58 @@ def test_render_recipe_meta(
     assert not rendered.noarch_python
 
 
-def test_render_recipe_v1_unsupported(tmp_path: Path) -> None:
-    """v1 recipes are rejected until #160 lands"""
+RENDERED_V1 = {
+    "schema_version": 1,
+    "package": {"name": "simple", "version": "1.2.3"},
+    "source": [{"path": "../"}],
+    "build": {
+        "number": 2,
+        "string": "pyh4616a5c_2",
+        "script": "pip install . -vv",
+        "noarch": "python",
+    },
+    "tests": [{"python": {"imports": ["simple"]}}],
+}
+
+
+def test_render_recipe_v1(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """render_recipe normalizes rendered v1 recipes"""
     recipe_dir = tmp_path / "recipe"
     recipe_dir.mkdir()
-    (recipe_dir / "recipe.yaml").write_text("package: {name: foo}")
-    with pytest.raises(RecipeError, match="not yet supported"):
+    recipe_file = recipe_dir / "recipe.yaml"
+    recipe_file.write_text("unrendered")
+
+    rendered_raw = dict(RENDERED_V1)
+    monkeypatch.setattr(
+        "whl2conda.impl.render_v1.render_v1_yaml",
+        lambda _recipe_file: dict(rendered_raw),
+    )
+
+    rendered = render_recipe(recipe_dir, tmp_path / "work")
+    assert rendered.format is RecipeFormat.V1
+    assert rendered.recipe_dir == recipe_dir
+    assert rendered.name == "simple"
+    assert rendered.version == "1.2.3"
+    assert rendered.build_number == 2
+    assert rendered.build_script == ["pip install . -vv"]
+    assert rendered.noarch_python
+    assert rendered.raw == RENDERED_V1
+
+    # the v1 object script form
+    rendered_raw["build"] = {
+        "noarch": "python",
+        "script": {"content": ["echo before", "pip install ."], "env": {"X": "1"}},
+    }
+    rendered = render_recipe(recipe_dir, tmp_path / "work")
+    assert rendered.build_script == ["echo before", "pip install ."]
+    assert rendered.build_number == 0
+
+    # non-noarch v1 recipes are rejected
+    rendered_raw["build"] = {"script": "pip install ."}
+    with pytest.raises(RecipeError, match="noarch: python"):
         render_recipe(recipe_dir, tmp_path / "work")
 
 
@@ -297,3 +345,134 @@ def test_render_meta_yaml_failure(
     monkeypatch.setattr("whl2conda.impl.render_meta.subprocess.run", fake_run_noop)
     with pytest.raises(RecipeRenderError, match="did not produce"):
         render_meta_yaml(recipe_dir, work_dir)
+
+
+#
+# render_v1 backends
+#
+
+
+def _fake_rattler_module(*, multi=False, parse_fail=False, render_fail=False):
+    """Create a fake rattler_build module rendering RENDERED_V1."""
+    mod = types.ModuleType("rattler_build")
+
+    class FakeRendered:
+        class recipe:
+            @staticmethod
+            def to_dict() -> dict:
+                return dict(RENDERED_V1)
+
+    class Stage0Recipe:
+        paths: ClassVar[list[str]] = []
+
+        @classmethod
+        def from_file(cls, path: str) -> Stage0Recipe:
+            if parse_fail:
+                raise ValueError("bad yaml")
+            cls.paths.append(path)
+            return cls()
+
+        def as_single_output(self) -> None:
+            if multi:
+                raise TypeError("multi-output recipe")
+
+        def render(self) -> list:
+            if render_fail:
+                raise ValueError("render boom")
+            return [FakeRendered()]
+
+    mod.Stage0Recipe = Stage0Recipe  # type: ignore[attr-defined]
+    return mod
+
+
+def test_render_v1_yaml_in_process(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Whitebox test of the py-rattler-build render backend"""
+    recipe_file = tmp_path / "recipe.yaml"
+    recipe_file.write_text("unrendered")
+    monkeypatch.setattr(
+        "whl2conda.impl.render_v1.importlib.util.find_spec",
+        lambda _name: object(),
+    )
+
+    fake = _fake_rattler_module()
+    monkeypatch.setitem(sys.modules, "rattler_build", fake)
+    assert render_v1_yaml(recipe_file) == RENDERED_V1
+    assert fake.Stage0Recipe.paths == [str(recipe_file)]
+
+    monkeypatch.setitem(sys.modules, "rattler_build", _fake_rattler_module(multi=True))
+    with pytest.raises(RecipeError, match="multiple outputs"):
+        render_v1_yaml(recipe_file)
+
+    monkeypatch.setitem(
+        sys.modules, "rattler_build", _fake_rattler_module(parse_fail=True)
+    )
+    with pytest.raises(RecipeRenderError, match="bad yaml"):
+        render_v1_yaml(recipe_file)
+
+    monkeypatch.setitem(
+        sys.modules, "rattler_build", _fake_rattler_module(render_fail=True)
+    )
+    with pytest.raises(RecipeRenderError, match="render boom"):
+        render_v1_yaml(recipe_file)
+
+
+def test_render_v1_yaml_cli(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Whitebox test of the rattler-build executable render backend"""
+    recipe_file = tmp_path / "recipe.yaml"
+    recipe_file.write_text("unrendered")
+
+    # force the executable path even if py-rattler-build is importable
+    monkeypatch.setattr(
+        "whl2conda.impl.render_v1.importlib.util.find_spec", lambda _name: None
+    )
+
+    # no rattler-build executable either
+    monkeypatch.setattr("whl2conda.impl.render_v1.shutil.which", lambda _name: None)
+    with pytest.raises(RecipeError, match="requires either"):
+        render_v1_yaml(recipe_file)
+
+    monkeypatch.setattr(
+        "whl2conda.impl.render_v1.shutil.which", lambda _name: "/bin/rattler-build"
+    )
+
+    commands: list[list[str]] = []
+    stdout = json.dumps([{"recipe": RENDERED_V1}])
+    returncode = 0
+
+    def fake_run(cmd, capture_output=False, encoding="", check=False):
+        commands.append(cmd)
+        return subprocess.CompletedProcess(cmd, returncode, stdout=stdout, stderr="")
+
+    monkeypatch.setattr("whl2conda.impl.render_v1.subprocess.run", fake_run)
+
+    assert render_v1_yaml(recipe_file) == RENDERED_V1
+    cmd = commands[0]
+    assert cmd[0] == "/bin/rattler-build"
+    assert "--render-only" in cmd
+    assert str(recipe_file) in cmd
+
+    # multiple outputs are rejected
+    stdout = json.dumps([{"recipe": RENDERED_V1}, {"recipe": RENDERED_V1}])
+    with pytest.raises(RecipeError, match="multiple outputs"):
+        render_v1_yaml(recipe_file)
+
+    # unparseable output
+    stdout = "this is not json"
+    with pytest.raises(RecipeRenderError, match="Cannot parse"):
+        render_v1_yaml(recipe_file)
+
+    # render failure reports stderr
+    returncode = 1
+
+    def fake_run_fail(cmd, capture_output=False, encoding="", check=False):
+        return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="no such recipe")
+
+    monkeypatch.setattr("whl2conda.impl.render_v1.subprocess.run", fake_run_fail)
+    with pytest.raises(RecipeRenderError, match="no such recipe"):
+        render_v1_yaml(recipe_file)

--- a/zensical.toml
+++ b/zensical.toml
@@ -22,6 +22,7 @@ nav = [
     { "Dependency Modification" = "guide/renaming.md" },
     { "Configuring pyproject.toml" = "guide/pyproject.md" },
     { "Binary Conversion" = "guide/binary-conversion.md" },
+    { "Building from Recipes" = "guide/building.md" },
     { "Installing and Testing" = "guide/testing.md" },
     { "Limitations" = "guide/limitations.md" },
   ] },


### PR DESCRIPTION
Final PR in the `whl2conda build` series (stacked on #213; base will be retargeted as the stack merges).

Implements #160: `whl2conda build` now handles v1 (`recipe.yaml`) recipes as built by rattler-build, completing the goal of making the command usable for evaluating whl2conda against existing recipes of either format.

## Rendering (new `impl/render_v1.py`)

Three-tier strategy with no homegrown renderer:
1. **py-rattler-build in-process** (`Stage0Recipe.from_file(...).render()`) when the python bindings are importable,
2. **`rattler-build build --render-only`** executable fallback with checked exit status and JSON output parsing,
3. otherwise a clear error telling the user to install one of them.

Multi-output recipes are rejected (#104 is out of scope), and v1 recipes must declare `noarch: python` (hard error otherwise, per #160). Both tiers produce the identical rendered-recipe dictionary (verified against rattler-build 0.68).

## Build pipeline

- v1 `tests:` lists run against the generated package through the shared test runner from #211 (`python.imports`/`pip_check`, `script` with `requirements.run` and `files.source`; `package_contents`/`downstream` warn-ignored). All elements run in one shared test environment — documented fidelity difference from rattler-build.
- The build script and test source files now resolve from the recipe's **source directory**: conda-build's populated work dir when present, otherwise the recipe's local `path:` source. Previously the build script ran in the invoker's current directory, so `whl2conda build` had to be run from the project root. (Also fixed: an *empty* conda-build work dir — created when the recipe's jinja never touches the source — is no longer mistaken for the source.)
- The in-process conda-build render now captures conda-build's stdout chatter so `--output` prints only the package path (it was corrupting the render-only mode from #213).

## Fixture + tests

- New `test-projects/recipe/` fixture: a minimal hatchling project with **equivalent classic and v1 recipes** (`recipe-meta/meta.yaml`, `recipe-v1/recipe.yaml`) including build number, test requirements, imports, source files, and commands.
- Unit tests for both render tiers (fake `rattler_build` module / mocked subprocess), v1 normalization (object script form, noarch rejection), and the v1 test-spec dispatch in the whitebox harness.
- External e2e tests build both fixture recipes for real (render → wheel → convert), verify `--output` prediction equals the artifact path, `--skip-existing`, and `--check`. Slow-marked e2e tests additionally run the recipes' tests in a fresh conda environment and exercise `-t` — verified locally for both formats.

## Docs & packaging

- New **"Building from Recipes"** user guide page covering both formats, the option compatibility policy, and the evaluation workflow (`whl2conda build` + `whl2conda diff`).
- Build command help updated for both formats; the "experimental" label is dropped.
- `rattler-build` and `py-rattler-build` added to the pixi test feature (previously only present transitively).

🤖 Generated with [Claude Code](https://claude.com/claude-code)