### PR TITLE
Extras handling: warnings, rename rules, known-extras table, and --resolve-extras (#36, #217)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,18 @@
   `ray[default]`, `black[jupyter]`), the warning names the
   corresponding conda package, and the new `--known-extras` option
   applies those replacements automatically. (#217)
+* New `--resolve-extras` option resolves remaining dependency extras
+  from pypi.org metadata: the extra's dependencies are read from the
+  newest release satisfying the dependency's version spec, converted
+  like regular dependencies, and any nested extras are resolved
+  recursively. This is a best-effort approximation, since the solver
+  may install a version whose extras differ. (#36)
 
 ### Changes
 
+* New runtime dependency on `packaging` (used to select release
+  versions when resolving extras from pypi metadata; it was already
+  used opportunistically for dependency marker evaluation).
 * `whl2conda build` renders recipes into its own temporary work
   directory (instead of scraping conda-build console output to locate
   scratch space in conda-bld), checks the exit status of the render,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
   conda build options are accepted and ignored with a warning, except
   upload/signing and non-python language options, which are rejected
   with an error. (#110)
+* Dependencies with extras (`name[extra,...]`) now generate a warning
+  when the extras are dropped, instead of dropping them silently, and
+  dependency rename rules are matched against the bracketed form first
+  so such dependencies can be mapped to a corresponding conda package
+  (e.g. `dask[complete]` to `dask`). (#217)
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,11 @@
   when the extras are dropped, instead of dropping them silently, and
   dependency rename rules are matched against the bracketed form first
   so such dependencies can be mapped to a corresponding conda package
-  (e.g. `dask[complete]` to `dask`). (#217)
+  (e.g. `dask[complete]` to `dask`). For a built-in table of common
+  extras with dedicated conda-forge packages (e.g. `uvicorn[standard]`,
+  `ray[default]`, `black[jupyter]`), the warning names the
+  corresponding conda package, and the new `--known-extras` option
+  applies those replacements automatically. (#217)
 
 ### Changes
 

--- a/doc/guide/renaming.md
+++ b/doc/guide/renaming.md
@@ -184,6 +184,22 @@ apply these replacements automatically:
 $ whl2conda convert --known-extras ...
 ```
 
+Extras not handled by any of the above can be resolved from
+[pypi.org] metadata using the `--resolve-extras` option, which
+requires network access:
+
+```bash
+$ whl2conda convert --resolve-extras ...
+```
+
+This reads the extra's dependencies from the newest release of the
+package that satisfies the dependency's version spec, converts them
+like regular dependencies, and recursively resolves any extras they
+use in turn. Note that this is a best-effort approximation: the
+extra's dependencies are taken from one specific version of the
+package, while the conda solver may ultimately install a different
+version whose extras differ.
+
 ### Renaming converted package
 
 By default, the name of the generated conda package will be taken

--- a/doc/guide/renaming.md
+++ b/doc/guide/renaming.md
@@ -142,6 +142,28 @@ be replaced with the named capture group with given name.
     $ whl2conda convert -R 'acme-(?P<part>.*)' 'acme.${part}'
     ```
 
+### <a name="extras">Dependencies with extras</a>
+
+Conda packages cannot express pip *extras*, so by default the
+extras are dropped with a warning from dependencies of the form
+`name[extra,...]` — only the base package dependency is kept.
+
+Rename rules are matched against the bracketed form of such
+dependencies (as written in the wheel metadata) before the bare
+name, so where a corresponding conda package exists — for example,
+on conda-forge the `dask` metapackage corresponds to
+`dask[complete]`, while plain `dask` corresponds to `dask-core` —
+you can map the dependency explicitly, which also suppresses the
+warning:
+
+```bash
+$ whl2conda convert -R 'dask\[complete\]' dask -R dask dask-core
+```
+
+Note that the square brackets must be escaped in the regular
+expression pattern. Alternatively, the extra's dependencies can be
+added individually using `-A` / `--add-dependency`.
+
 ### Renaming converted package
 
 By default, the name of the generated conda package will be taken

--- a/doc/guide/renaming.md
+++ b/doc/guide/renaming.md
@@ -160,9 +160,11 @@ warning:
 $ whl2conda convert -R 'dask\[complete\]' dask -R dask dask-core
 ```
 
-Note that the square brackets must be escaped in the regular
-expression pattern. Alternatively, the extra's dependencies can be
-added individually using `-A` / `--add-dependency`.
+Note that the square brackets are escaped because the pattern is
+a regular expression, in which unescaped brackets would denote a
+character class — this is independent of any shell quoting.
+Alternatively, the extra's dependencies can be added individually
+using `-A` / `--add-dependency`.
 
 *whl2conda* also knows about a number of common extras that have a
 dedicated corresponding package on [conda-forge], including:
@@ -195,10 +197,15 @@ $ whl2conda convert --resolve-extras ...
 This reads the extra's dependencies from the newest release of the
 package that satisfies the dependency's version spec, converts them
 like regular dependencies, and recursively resolves any extras they
-use in turn. Note that this is a best-effort approximation: the
-extra's dependencies are taken from one specific version of the
-package, while the conda solver may ultimately install a different
-version whose extras differ.
+use in turn.
+
+!!! warning
+
+    This is a best-effort approximation: the extra's dependencies
+    are taken from one specific version of the package, while the
+    conda solver may ultimately install a different version whose
+    extras differ. Review the resulting dependencies when using
+    this option.
 
 ### Renaming converted package
 

--- a/doc/guide/renaming.md
+++ b/doc/guide/renaming.md
@@ -164,6 +164,26 @@ Note that the square brackets must be escaped in the regular
 expression pattern. Alternatively, the extra's dependencies can be
 added individually using `-A` / `--add-dependency`.
 
+*whl2conda* also knows about a number of common extras that have a
+dedicated corresponding package on [conda-forge], including:
+
+| pypi dependency | conda package |
+|---|---|
+| `black[jupyter]` | `black-jupyter` |
+| `dask[complete]` | `dask` |
+| `ibis-framework[<backend>]` | `ibis-<backend>` |
+| `psycopg[binary]`, `psycopg[c]` | `psycopg` |
+| `ray[default]`, `ray[serve]`, ... | `ray-default`, `ray-serve`, ... |
+| `uvicorn[standard]` | `uvicorn-standard` |
+
+When such a dependency is encountered, the warning will point out the
+corresponding conda package, and the `--known-extras` option will
+apply these replacements automatically:
+
+```bash
+$ whl2conda convert --known-extras ...
+```
+
 ### Renaming converted package
 
 By default, the name of the generated conda package will be taken

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ classifiers = [
 ]
 keywords = ["conda", "wheel", "build"]
 requires-python = ">=3.10"
+# NOTE: new runtime dependencies must also be added to the recipe in
+# the conda-forge whl2conda-feedstock when updating it for a release
 dependencies = [
     "conda-package-handling >=2.2",
     "packaging >=23",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ keywords = ["conda", "wheel", "build"]
 requires-python = ">=3.10"
 dependencies = [
     "conda-package-handling >=2.2",
+    "packaging >=23",
     "platformdirs >=3.10",
     "pyyaml >=6.0",
     "tomlkit >=0.12",
@@ -49,6 +50,7 @@ platforms = ["win-64", "linux-64", "osx-arm64"]
 python = ">=3.10,<3.15"
 # Use "*" to reference project dependencies without duplicating version specs
 conda-package-handling = "*"
+packaging = "*"
 platformdirs = "*"
 pyyaml = "*"
 tomlkit = "*"

--- a/src/whl2conda/api/compare.py
+++ b/src/whl2conda/api/compare.py
@@ -177,7 +177,7 @@ class CompareOptions:
     renames: dict[str, str] | None = None
     """pypi to conda package rename map.
 
-    Defaults to the standard rename table from [load_std_renames][(m)..stdrename.].
+    Defaults to the standard rename table from [load_std_renames][whl2conda.api.stdrename.].
     """
 
 

--- a/src/whl2conda/api/converter.py
+++ b/src/whl2conda/api/converter.py
@@ -454,6 +454,11 @@ class DependencyRename(NamedTuple):
     The pattern must fully match the input package.
     The replacement string may contain group references
     e.g. r'\1', r'\g<name>`.
+
+    For dependencies with extras, patterns are first matched against
+    the bracketed `name[extra,...]` form (as written in the wheel
+    metadata), so that a dependency with extras can be mapped to a
+    corresponding conda package, e.g. `dask\[complete\]` -> `dask`.
     """
 
     pattern: re.Pattern
@@ -1009,17 +1014,41 @@ class Wheel2CondaConverter:
                     )
                     version = self.python_version
 
-            # TODO - do something with extras (#36)
-            #   download target pip package and its extra dependencies
             # check manual renames first
             renamed = False
-            for renamer in self.dependency_rename:
-                conda_name, renamed = renamer.rename(pip_name)
-                if renamed:
-                    break
+            extras_handled = not entry.extras
+            extras_name = pip_name
+            if entry.extras:
+                # a rule matching the bracketed name[extra,...] form maps
+                # the dependency with its extras to a conda equivalent,
+                # e.g. 'dask[complete]' -> 'dask' (#217)
+                extras_name = f"{pip_name}[{','.join(entry.extras)}]"
+                for renamer in self.dependency_rename:
+                    conda_name, renamed = renamer.rename(extras_name)
+                    if renamed:
+                        extras_handled = True
+                        break
+            if not renamed:
+                conda_name = pip_name
+                for renamer in self.dependency_rename:
+                    conda_name, renamed = renamer.rename(pip_name)
+                    if renamed:
+                        break
             if not renamed:
                 conda_name = self.std_renames.get(
                     normalize_pypi_name(pip_name), pip_name
+                )
+
+            if conda_name and not extras_handled:
+                # TODO - optionally resolve extras from pypi metadata (#36)
+                self._warn(
+                    "Dropping extras [%s] from dependency '%s': conda"
+                    " packages cannot express extras. Add the extra's"
+                    " dependencies with --extra-dep, or map '%s' to a"
+                    " conda equivalent with a dependency rename rule.",
+                    ",".join(entry.extras),
+                    entry,
+                    extras_name,
                 )
 
             if conda_name:

--- a/src/whl2conda/api/converter.py
+++ b/src/whl2conda/api/converter.py
@@ -24,6 +24,8 @@ import dataclasses
 import email
 import email.message
 import email.policy
+import functools
+import importlib.resources
 import io
 import json
 import logging
@@ -523,54 +525,19 @@ class DependencyRename(NamedTuple):
         return pypi_name, False
 
 
-#: Known conda-forge packages corresponding to pypi extras, keyed by
-#: normalized pypi package name and then by normalized extra name.
-#: Only extras with a dedicated conda-forge package that uses the same
-#: version numbering as, and also depends on (or subsumes), the base
-#: package belong in this table: the mapped package *replaces* the
-#: bracketed dependency, carrying over its version spec.
-KNOWN_EXTRA_PACKAGES: dict[str, dict[str, str]] = {
-    "black": {"jupyter": "black-jupyter"},
-    "dask": {"complete": "dask"},
-    "ibis-framework": {
-        extra: f"ibis-{extra}"
-        for extra in (
-            "bigquery",
-            "clickhouse",
-            "datafusion",
-            "duckdb",
-            "exasol",
-            "impala",
-            "mssql",
-            "mysql",
-            "oracle",
-            "polars",
-            "postgres",
-            "pyspark",
-            "snowflake",
-            "sqlite",
-            "trino",
-        )
-    },
-    # the binary/c extras select the psycopg implementation, which is
-    # not meaningful for conda packages: the base package suffices
-    "psycopg": {"binary": "psycopg", "c": "psycopg"},
-    "ray": {
-        extra: f"ray-{extra}"
-        for extra in (
-            "air",
-            "all",
-            "client",
-            "data",
-            "default",
-            "rllib",
-            "serve",
-            "train",
-            "tune",
-        )
-    },
-    "uvicorn": {"standard": "uvicorn-standard"},
-}
+@functools.cache
+def load_known_extras() -> dict[str, dict[str, str]]:
+    """Table of known conda-forge packages corresponding to pypi extras.
+
+    Loaded from the bundled `known_extras.json` data file, keyed by
+    normalized pypi package name and then by normalized extra name.
+    Only extras with a dedicated conda-forge package that uses the same
+    version numbering as, and also depends on (or subsumes), the base
+    package belong in this table: the mapped package *replaces* the
+    bracketed dependency, carrying over its version spec.
+    """
+    resources = importlib.resources.files("whl2conda.api")
+    return json.loads(resources.joinpath("known_extras.json").read_text("utf8"))
 
 
 class Wheel2CondaConverter:
@@ -1107,7 +1074,7 @@ class Wheel2CondaConverter:
             # extras with known corresponding conda packages (#217)
             known_extras: dict[str, str] = {}
             if dropped_extras:
-                known = KNOWN_EXTRA_PACKAGES.get(normalize_pypi_name(pip_name), {})
+                known = load_known_extras().get(normalize_pypi_name(pip_name), {})
                 known_extras = {
                     extra: known[normalize_pypi_name(extra)]
                     for extra in dropped_extras
@@ -1164,11 +1131,11 @@ class Wheel2CondaConverter:
                 # TODO - optionally resolve extras from pypi metadata (#36)
                 if known_extras:
                     known_names = ", ".join(
-                        f"'{name}'" for name in dict.fromkeys(known_extras.values())
+                        f"'{conda_pkg}' for [{extra}]"
+                        for extra, conda_pkg in known_extras.items()
                     )
                     hint = (
-                        f" Note: conda-forge provides {known_names} for the"
-                        f" [{','.join(known_extras)}] extras; use the"
+                        f" Note: conda-forge provides {known_names}; use the"
                         " --known-extras option to apply this automatically."
                     )
                 else:
@@ -1269,11 +1236,7 @@ class Wheel2CondaConverter:
         from packaging.version import InvalidVersion, Version  # noqa: PLC0415
 
         norm_name = normalize_pypi_name(package)
-        cache_key = (norm_name, version_spec)
-        if cached := self._pypi_metadata_cache.get(cache_key):
-            return cached
-
-        data = fetch_pypi_metadata(norm_name)
+        data = self._pypi_metadata(norm_name)
         latest = (data.get("info") or {}).get("version") or ""
         target = latest
         if version_spec:
@@ -1289,9 +1252,21 @@ class Wheel2CondaConverter:
             if candidates:
                 target = str(max(candidates))
         if target and target != latest:
-            data = fetch_pypi_metadata(norm_name, target)
-        self._pypi_metadata_cache[cache_key] = data
+            data = self._pypi_metadata(norm_name, target)
         return data
+
+    def _pypi_metadata(self, package: str, version: str = "") -> dict[str, Any]:
+        """Fetch pypi metadata, cached per package and version.
+
+        The cache is per converter instance rather than a global
+        functools cache so that repeated conversions cannot see
+        stale metadata and instances do not leak.
+        """
+        cache_key = (package, version)
+        if (cached := self._pypi_metadata_cache.get(cache_key)) is None:
+            cached = fetch_pypi_metadata(package, version)
+            self._pypi_metadata_cache[cache_key] = cached
+        return cached
 
     def _add_binary_dependencies(
         self,

--- a/src/whl2conda/api/converter.py
+++ b/src/whl2conda/api/converter.py
@@ -31,6 +31,7 @@ import re
 import shutil
 import tempfile
 import time
+from collections import deque
 from collections.abc import Sequence
 from dataclasses import dataclass
 from hashlib import sha256
@@ -43,6 +44,7 @@ from conda_package_handling.api import create as create_conda_pkg
 # this project
 from ..__about__ import __version__
 from ..impl.conda_forge import native_conda_subdir
+from ..impl.download import fetch_pypi_metadata
 from ..impl.prompt import bool_input
 from ..impl.pyproject import CondaPackageFormat
 from ..impl.wheel import unpack_wheel
@@ -447,6 +449,21 @@ def _evaluate_marker(marker: str, env: dict[str, str]) -> bool:
         return True
 
 
+def _strip_extra_marker(entry: RequiresDistEntry) -> RequiresDistEntry:
+    """Return copy of entry with the `extra == ...` marker clause removed."""
+    new_entry = dataclasses.replace(
+        entry, marker="", extra_marker_name="", generic=True
+    )
+    if not entry.generic:
+        marker = re.sub(r"\s*\band\b\s*extra\s*==\s*(['\"])[^'\"]*\1", "", entry.marker)
+        marker = re.sub(
+            r"extra\s*==\s*(['\"])[^'\"]*\1\s*\band\b\s*", "", marker
+        ).strip()
+        if marker:
+            new_entry.set_marker(marker)
+    return new_entry
+
+
 class DependencyRename(NamedTuple):
     r"""
     Defines a pypi to conda package renaming rule.
@@ -602,6 +619,8 @@ class Wheel2CondaConverter:
     extra_dependencies: list[str]
     use_known_extras: bool = False
     """Replace known pypi extras with corresponding conda packages"""
+    resolve_extras: bool = False
+    """Resolve remaining extras from pypi metadata (best effort)"""
     python_version: str = ""
     interactive: bool = False
     build_number: int | None = None
@@ -627,6 +646,7 @@ class Wheel2CondaConverter:
         self.out_dir = out_dir
         self.dependency_rename = []
         self.extra_dependencies = []
+        self._pypi_metadata_cache: dict[tuple[str, str], dict[str, Any]] = {}
         # TODO - option to ignore this
         self.std_renames = load_std_renames(update=update_std_renames)
 
@@ -1035,7 +1055,10 @@ class Wheel2CondaConverter:
 
         saw_python = False
 
-        for entry in dependencies:
+        queue = deque(dependencies)
+        resolved_extras: set[tuple[str, str]] = set()
+        while queue:
+            entry = queue.popleft()
             if entry.extra_marker_name:
                 self._debug("Skipping extra dependency: %s", entry)
                 continue
@@ -1107,6 +1130,25 @@ class Wheel2CondaConverter:
                     # the mapped conda packages subsume the base package
                     continue
 
+            # resolve remaining extras from pypi metadata (#36)
+            if dropped_extras and self.resolve_extras and not renamed:
+                remaining: list[str] = []
+                for extra in dropped_extras:
+                    key = (
+                        normalize_pypi_name(pip_name),
+                        normalize_pypi_name(extra),
+                    )
+                    if key in resolved_extras:
+                        continue  # already expanded (or cyclic)
+                    resolved_extras.add(key)
+                    expansion = self._resolve_extra(pip_name, entry.version, extra)
+                    if expansion is None:
+                        remaining.append(extra)
+                    else:
+                        queue.extend(expansion)
+                dropped_extras = remaining
+                known_extras = {}
+
             if not renamed:
                 conda_name = pip_name
                 for renamer in self.dependency_rename:
@@ -1131,9 +1173,10 @@ class Wheel2CondaConverter:
                     )
                 else:
                     hint = (
-                        " Add the extra's dependencies with --extra-dep, or"
-                        f" map '{extras_name}' to a conda equivalent with a"
-                        " dependency rename rule."
+                        " Add the extra's dependencies with --extra-dep, map"
+                        f" '{extras_name}' to a conda equivalent with a"
+                        " dependency rename rule, or use the --resolve-extras"
+                        " option to resolve them from pypi metadata."
                     )
                 self._warn(
                     "Dropping extras [%s] from dependency '%s': conda"
@@ -1161,6 +1204,94 @@ class Wheel2CondaConverter:
             self._debug("Dependency added:  '%s'", dep)
             conda_dependencies.append(dep)
         return conda_dependencies
+
+    def _resolve_extra(
+        self,
+        package: str,
+        version_spec: str,
+        extra: str,
+    ) -> list[RequiresDistEntry] | None:
+        """Resolve an extra's dependencies from pypi metadata.
+
+        Reads the Requires-Dist metadata of the newest release of
+        `package` satisfying `version_spec` from pypi.org and returns
+        the entries belonging to the given extra, with the extra
+        marker clause removed. This is a best-effort approximation:
+        the extra's dependencies are taken from one specific version,
+        which is not necessarily the version a solver will install.
+
+        Returns:
+            The extra's dependency entries, or None if the metadata
+            could not be fetched or the extra is unknown.
+        """
+        try:
+            data = self._get_pypi_metadata(package, version_spec)
+            info = data.get("info") or {}
+            requires_dist = info.get("requires_dist") or []
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            self._warn("Cannot fetch pypi metadata for '%s': %s", package, ex)
+            return None
+
+        norm_extra = normalize_pypi_name(extra)
+        if norm_extra not in (
+            normalize_pypi_name(provided)
+            for provided in info.get("provides_extra") or ()
+        ):
+            self._warn(
+                "Package '%s' version %s does not provide extra '%s'",
+                package,
+                info.get("version"),
+                extra,
+            )
+            return None
+
+        entries = []
+        for raw in requires_dist:
+            try:
+                entry = RequiresDistEntry.parse(raw)
+            except SyntaxError:
+                continue
+            if normalize_pypi_name(entry.extra_marker_name) == norm_extra:
+                entries.append(_strip_extra_marker(entry))
+        self._info(
+            "Resolved '%s[%s]' using version %s metadata: %s",
+            package,
+            extra,
+            info.get("version"),
+            ", ".join(str(e) for e in entries) or "no dependencies",
+        )
+        return entries
+
+    def _get_pypi_metadata(self, package: str, version_spec: str) -> dict[str, Any]:
+        """Get pypi metadata for newest release matching the version spec."""
+        # standard
+        from packaging.specifiers import SpecifierSet  # noqa: PLC0415
+        from packaging.version import InvalidVersion, Version  # noqa: PLC0415
+
+        norm_name = normalize_pypi_name(package)
+        cache_key = (norm_name, version_spec)
+        if cached := self._pypi_metadata_cache.get(cache_key):
+            return cached
+
+        data = fetch_pypi_metadata(norm_name)
+        latest = (data.get("info") or {}).get("version") or ""
+        target = latest
+        if version_spec:
+            specifiers = SpecifierSet(version_spec)
+            candidates = []
+            for release in data.get("releases") or {}:
+                try:
+                    version = Version(release)
+                except InvalidVersion:
+                    continue
+                if not version.is_prerelease and version in specifiers:
+                    candidates.append(version)
+            if candidates:
+                target = str(max(candidates))
+        if target and target != latest:
+            data = fetch_pypi_metadata(norm_name, target)
+        self._pypi_metadata_cache[cache_key] = data
+        return data
 
     def _add_binary_dependencies(
         self,

--- a/src/whl2conda/api/converter.py
+++ b/src/whl2conda/api/converter.py
@@ -506,6 +506,56 @@ class DependencyRename(NamedTuple):
         return pypi_name, False
 
 
+#: Known conda-forge packages corresponding to pypi extras, keyed by
+#: normalized pypi package name and then by normalized extra name.
+#: Only extras with a dedicated conda-forge package that uses the same
+#: version numbering as, and also depends on (or subsumes), the base
+#: package belong in this table: the mapped package *replaces* the
+#: bracketed dependency, carrying over its version spec.
+KNOWN_EXTRA_PACKAGES: dict[str, dict[str, str]] = {
+    "black": {"jupyter": "black-jupyter"},
+    "dask": {"complete": "dask"},
+    "ibis-framework": {
+        extra: f"ibis-{extra}"
+        for extra in (
+            "bigquery",
+            "clickhouse",
+            "datafusion",
+            "duckdb",
+            "exasol",
+            "impala",
+            "mssql",
+            "mysql",
+            "oracle",
+            "polars",
+            "postgres",
+            "pyspark",
+            "snowflake",
+            "sqlite",
+            "trino",
+        )
+    },
+    # the binary/c extras select the psycopg implementation, which is
+    # not meaningful for conda packages: the base package suffices
+    "psycopg": {"binary": "psycopg", "c": "psycopg"},
+    "ray": {
+        extra: f"ray-{extra}"
+        for extra in (
+            "air",
+            "all",
+            "client",
+            "data",
+            "default",
+            "rllib",
+            "serve",
+            "train",
+            "tune",
+        )
+    },
+    "uvicorn": {"standard": "uvicorn-standard"},
+}
+
+
 class Wheel2CondaConverter:
     """
     Converter supports generation of a conda package from a python wheel.
@@ -550,6 +600,8 @@ class Wheel2CondaConverter:
     keep_pip_dependencies: bool = False
     dependency_rename: list[DependencyRename]
     extra_dependencies: list[str]
+    use_known_extras: bool = False
+    """Replace known pypi extras with corresponding conda packages"""
     python_version: str = ""
     interactive: bool = False
     build_number: int | None = None
@@ -1016,7 +1068,7 @@ class Wheel2CondaConverter:
 
             # check manual renames first
             renamed = False
-            extras_handled = not entry.extras
+            dropped_extras = list(entry.extras)
             extras_name = pip_name
             if entry.extras:
                 # a rule matching the bracketed name[extra,...] form maps
@@ -1026,8 +1078,35 @@ class Wheel2CondaConverter:
                 for renamer in self.dependency_rename:
                     conda_name, renamed = renamer.rename(extras_name)
                     if renamed:
-                        extras_handled = True
+                        dropped_extras = []
                         break
+
+            # extras with known corresponding conda packages (#217)
+            known_extras: dict[str, str] = {}
+            if dropped_extras:
+                known = KNOWN_EXTRA_PACKAGES.get(normalize_pypi_name(pip_name), {})
+                known_extras = {
+                    extra: known[normalize_pypi_name(extra)]
+                    for extra in dropped_extras
+                    if normalize_pypi_name(extra) in known
+                }
+            if known_extras and self.use_known_extras:
+                dropped_extras = [
+                    extra for extra in dropped_extras if extra not in known_extras
+                ]
+                for mapped in dict.fromkeys(known_extras.values()):
+                    conda_dep = f"{mapped} {version}"
+                    self._info(
+                        "Replaced extras dependency: '%s' -> '%s'",
+                        entry,
+                        conda_dep,
+                    )
+                    conda_dependencies.append(conda_dep)
+                known_extras = {}
+                if not dropped_extras:
+                    # the mapped conda packages subsume the base package
+                    continue
+
             if not renamed:
                 conda_name = pip_name
                 for renamer in self.dependency_rename:
@@ -1039,16 +1118,29 @@ class Wheel2CondaConverter:
                     normalize_pypi_name(pip_name), pip_name
                 )
 
-            if conda_name and not extras_handled:
+            if conda_name and dropped_extras:
                 # TODO - optionally resolve extras from pypi metadata (#36)
+                if known_extras:
+                    known_names = ", ".join(
+                        f"'{name}'" for name in dict.fromkeys(known_extras.values())
+                    )
+                    hint = (
+                        f" Note: conda-forge provides {known_names} for the"
+                        f" [{','.join(known_extras)}] extras; use the"
+                        " --known-extras option to apply this automatically."
+                    )
+                else:
+                    hint = (
+                        " Add the extra's dependencies with --extra-dep, or"
+                        f" map '{extras_name}' to a conda equivalent with a"
+                        " dependency rename rule."
+                    )
                 self._warn(
                     "Dropping extras [%s] from dependency '%s': conda"
-                    " packages cannot express extras. Add the extra's"
-                    " dependencies with --extra-dep, or map '%s' to a"
-                    " conda equivalent with a dependency rename rule.",
-                    ",".join(entry.extras),
+                    " packages cannot express extras.%s",
+                    ",".join(dropped_extras),
                     entry,
-                    extras_name,
+                    hint,
                 )
 
             if conda_name:

--- a/src/whl2conda/api/converter.py
+++ b/src/whl2conda/api/converter.py
@@ -459,7 +459,7 @@ def _strip_extra_marker(entry: RequiresDistEntry) -> RequiresDistEntry:
         marker = re.sub(
             r"extra\s*==\s*(['\"])[^'\"]*\1\s*\band\b\s*", "", marker
         ).strip()
-        if marker:
+        if marker:  # pragma: no branch
             new_entry.set_marker(marker)
     return new_entry
 

--- a/src/whl2conda/api/known_extras.json
+++ b/src/whl2conda/api/known_extras.json
@@ -1,0 +1,43 @@
+{
+  "black": {
+    "jupyter": "black-jupyter"
+  },
+  "dask": {
+    "complete": "dask"
+  },
+  "ibis-framework": {
+    "bigquery": "ibis-bigquery",
+    "clickhouse": "ibis-clickhouse",
+    "datafusion": "ibis-datafusion",
+    "duckdb": "ibis-duckdb",
+    "exasol": "ibis-exasol",
+    "impala": "ibis-impala",
+    "mssql": "ibis-mssql",
+    "mysql": "ibis-mysql",
+    "oracle": "ibis-oracle",
+    "polars": "ibis-polars",
+    "postgres": "ibis-postgres",
+    "pyspark": "ibis-pyspark",
+    "snowflake": "ibis-snowflake",
+    "sqlite": "ibis-sqlite",
+    "trino": "ibis-trino"
+  },
+  "psycopg": {
+    "binary": "psycopg",
+    "c": "psycopg"
+  },
+  "ray": {
+    "air": "ray-air",
+    "all": "ray-all",
+    "client": "ray-client",
+    "data": "ray-data",
+    "default": "ray-default",
+    "rllib": "ray-rllib",
+    "serve": "ray-serve",
+    "train": "ray-train",
+    "tune": "ray-tune"
+  },
+  "uvicorn": {
+    "standard": "uvicorn-standard"
+  }
+}

--- a/src/whl2conda/cli/convert.py
+++ b/src/whl2conda/cli/convert.py
@@ -71,6 +71,7 @@ class ConvertArgs:
     interactive: bool
     keep_pip_deps: bool
     known_extras: bool
+    resolve_extras: bool
     name: str
     out_dir: Path | None
     out_format: str
@@ -281,6 +282,18 @@ def _create_argparser(prog: str | None = None) -> argparse.ArgumentParser:
         help=dedent("""
             Replace dependencies with known extras by their corresponding
             conda packages, e.g. `uvicorn[standard]` by `uvicorn-standard`.
+            """),
+    )
+    override_opts.add_argument(
+        "--resolve-extras",
+        dest="resolve_extras",
+        action="store_true",
+        help=dedent("""
+            Resolve dependency extras not otherwise handled by reading
+            package metadata from pypi.org (requires network access).
+            The extra's dependencies are taken from the newest release
+            satisfying the dependency's version spec, so this is a
+            best-effort approximation.
             """),
     )
     override_opts.add_argument(
@@ -641,6 +654,7 @@ def convert_main(args: Sequence[str] | None = None, prog: str | None = None):
         converter.overwrite = parsed.overwrite
         converter.keep_pip_dependencies = parsed.keep_pip_deps
         converter.use_known_extras = parsed.known_extras
+        converter.resolve_extras = parsed.resolve_extras
         converter.extra_dependencies.extend(pyproj_info.extra_dependencies)
         converter.extra_dependencies.extend(parsed.extra_deps)
         converter.python_version = parsed.python

--- a/src/whl2conda/cli/convert.py
+++ b/src/whl2conda/cli/convert.py
@@ -249,7 +249,7 @@ def _create_argparser(prog: str | None = None) -> argparse.ArgumentParser:
         default=[],
         dest="dep_renames",
         help=dedent("""
-        Rename pip dependency for conda. May be specified muliple times.
+        Rename pip dependency for conda. May be specified multiple times.
         """),
     )
     override_opts.add_argument(

--- a/src/whl2conda/cli/convert.py
+++ b/src/whl2conda/cli/convert.py
@@ -70,6 +70,7 @@ class ConvertArgs:
     ignore_pyproject: bool
     interactive: bool
     keep_pip_deps: bool
+    known_extras: bool
     name: str
     out_dir: Path | None
     out_format: str
@@ -271,6 +272,15 @@ def _create_argparser(prog: str | None = None) -> argparse.ArgumentParser:
         help=dedent("""
             Drop dependency with given name from conda dependency list.
             May be specified multiple times.
+            """),
+    )
+    override_opts.add_argument(
+        "--known-extras",
+        dest="known_extras",
+        action="store_true",
+        help=dedent("""
+            Replace dependencies with known extras by their corresponding
+            conda packages, e.g. `uvicorn[standard]` by `uvicorn-standard`.
             """),
     )
     override_opts.add_argument(
@@ -630,6 +640,7 @@ def convert_main(args: Sequence[str] | None = None, prog: str | None = None):
         converter.out_format = out_fmt
         converter.overwrite = parsed.overwrite
         converter.keep_pip_dependencies = parsed.keep_pip_deps
+        converter.use_known_extras = parsed.known_extras
         converter.extra_dependencies.extend(pyproj_info.extra_dependencies)
         converter.extra_dependencies.extend(parsed.extra_deps)
         converter.python_version = parsed.python

--- a/src/whl2conda/impl/download.py
+++ b/src/whl2conda/impl/download.py
@@ -13,24 +13,49 @@
 #  limitations under the License.
 #
 """
-Support for downloading wheels
+Support for downloading wheels and pypi metadata
 """
 
 from __future__ import annotations
 
 import configparser
+import json
 import shutil
 import subprocess
 import sys
 import tempfile
+import urllib.request
 from pathlib import Path
+from typing import Any
 
 from ..settings import settings
 
 __all__ = [
     "download_wheel",
+    "fetch_pypi_metadata",
     "lookup_pypi_index",
 ]
+
+
+def fetch_pypi_metadata(package: str, version: str = "") -> dict[str, Any]:
+    """Fetch project metadata from the pypi.org JSON API.
+
+    Args:
+        package: pypi package name
+        version: specific version; when empty, the returned metadata
+            describes the latest version and includes all releases
+
+    Returns:
+        The decoded JSON metadata dictionary.
+
+    Raises:
+        urllib.error.URLError: if the metadata cannot be fetched.
+    """
+    url = f"https://pypi.org/pypi/{package}/json"
+    if version:
+        url = f"https://pypi.org/pypi/{package}/{version}/json"
+    with urllib.request.urlopen(url, timeout=30) as response:
+        return json.load(response)
 
 
 def lookup_pypi_index(index: str) -> str:

--- a/test/api/test_converter.py
+++ b/test/api/test_converter.py
@@ -26,6 +26,7 @@ import subprocess
 from collections.abc import Iterator
 from pathlib import Path
 from time import sleep
+from typing import Any
 
 # third party
 import pytest
@@ -1743,3 +1744,132 @@ def test_compute_dependencies_known_extras(
         ])
     assert result == ["my-uvicorn >=0.20"]
     assert "Dropping extras" not in caplog.text
+
+
+FAKE_PYPI_METADATA: dict[tuple[str, str], dict[str, Any]] = {
+    ("uvicorn", ""): {
+        "info": {
+            "version": "0.30.0",
+            "provides_extra": ["standard"],
+            "requires_dist": [
+                "click >=7.0",
+                "httptools >=0.6.0 ; extra == 'standard'",
+                "watchfiles >=0.13 ; extra == 'standard'",
+                "uvloop >=0.14.0 ; sys_platform != 'win32' and extra == 'standard'",
+            ],
+        },
+        "releases": {"0.29.0": [], "0.30.0": []},
+    },
+    ("uvicorn", "0.29.0"): {
+        "info": {
+            "version": "0.29.0",
+            "provides_extra": ["standard"],
+            "requires_dist": [
+                "click >=7.0",
+                "httptools >=0.5.0 ; extra == 'standard'",
+            ],
+        },
+    },
+    ("fastapi", ""): {
+        "info": {
+            "version": "0.110.0",
+            "provides_extra": ["all"],
+            "requires_dist": [
+                "starlette >=0.36",
+                "uvicorn[standard] >=0.20 ; extra == 'all'",
+                "orjson >=3.2 ; extra == 'all'",
+            ],
+        },
+        "releases": {"0.110.0": []},
+    },
+}
+
+
+def test_compute_dependencies_resolve_extras(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """resolve_extras expands extras from pypi metadata (#36)"""
+    fetches: list[tuple[str, str]] = []
+
+    def fake_fetch(package: str, version: str = "") -> dict[str, Any]:
+        fetches.append((package, version))
+        return FAKE_PYPI_METADATA[(package, version)]
+
+    monkeypatch.setattr("whl2conda.api.converter.fetch_pypi_metadata", fake_fetch)
+
+    converter = Wheel2CondaConverter(Path("fake.whl"), Path("."))
+    converter.logger = logging.getLogger(__name__)
+    converter.resolve_extras = True
+
+    # extras expand into the extra's dependencies plus the base package
+    with caplog.at_level(logging.WARNING):
+        result = converter._compute_conda_dependencies([
+            RequiresDistEntry.parse("uvicorn[standard] >=0.30")
+        ])
+    assert result == ["uvicorn >=0.30", "httptools >=0.6.0", "watchfiles >=0.13"]
+    assert "Dropping extras" not in caplog.text
+    # the platform-marker dependency is skipped as usual for noarch
+    assert "Skipping dependency with environment marker" in caplog.text
+    assert fetches == [("uvicorn", "")]
+
+    # the newest release satisfying the version spec is used
+    caplog.clear()
+    fetches.clear()
+    converter._pypi_metadata_cache.clear()
+    result = converter._compute_conda_dependencies([
+        RequiresDistEntry.parse("uvicorn[standard] <0.30")
+    ])
+    assert result == ["uvicorn <0.30", "httptools >=0.5.0"]
+    assert fetches == [("uvicorn", ""), ("uvicorn", "0.29.0")]
+
+    # nested extras are expanded recursively
+    caplog.clear()
+    converter._pypi_metadata_cache.clear()
+    with caplog.at_level(logging.WARNING):
+        result = converter._compute_conda_dependencies([
+            RequiresDistEntry.parse("fastapi[all] >=0.100")
+        ])
+    assert "fastapi >=0.100" in result
+    assert "uvicorn >=0.20" in result
+    assert "httptools >=0.6.0" in result
+    assert "orjson >=3.2" in result
+    assert "Dropping extras" not in caplog.text
+
+    # unknown extras fall back to the dropped-extras warning
+    caplog.clear()
+    converter._pypi_metadata_cache.clear()
+    with caplog.at_level(logging.WARNING):
+        result = converter._compute_conda_dependencies([
+            RequiresDistEntry.parse("uvicorn[nosuchextra] >=0.30")
+        ])
+    assert result == ["uvicorn >=0.30"]
+    assert "does not provide extra 'nosuchextra'" in caplog.text
+    assert "Dropping extras [nosuchextra]" in caplog.text
+
+    # fetch failures fall back to the dropped-extras warning
+    caplog.clear()
+
+    def failing_fetch(package: str, version: str = "") -> dict[str, Any]:
+        raise OSError("no network")
+
+    monkeypatch.setattr("whl2conda.api.converter.fetch_pypi_metadata", failing_fetch)
+    converter._pypi_metadata_cache.clear()
+    with caplog.at_level(logging.WARNING):
+        result = converter._compute_conda_dependencies([
+            RequiresDistEntry.parse("somepkg[fancy] >=1.0")
+        ])
+    assert result == ["somepkg >=1.0"]
+    assert "Cannot fetch pypi metadata for 'somepkg'" in caplog.text
+    assert "Dropping extras [fancy]" in caplog.text
+
+    # known extras take precedence over pypi resolution when enabled
+    fetches.clear()
+    monkeypatch.setattr("whl2conda.api.converter.fetch_pypi_metadata", fake_fetch)
+    converter.use_known_extras = True
+    converter._pypi_metadata_cache.clear()
+    result = converter._compute_conda_dependencies([
+        RequiresDistEntry.parse("uvicorn[standard] >=0.30")
+    ])
+    assert result == ["uvicorn-standard >=0.30"]
+    assert not fetches

--- a/test/api/test_converter.py
+++ b/test/api/test_converter.py
@@ -1627,11 +1627,22 @@ def test_compute_dependencies_extras(caplog: pytest.LogCaptureFixture) -> None:
     # extras are dropped with a warning by default
     with caplog.at_level(logging.WARNING):
         result = converter._compute_conda_dependencies([
+            RequiresDistEntry.parse("somepkg[fancy] >=1.0")
+        ])
+    assert result == ["somepkg >=1.0"]
+    assert "Dropping extras [fancy]" in caplog.text
+    assert "somepkg[fancy]" in caplog.text
+
+    # for known extras, the warning suggests the conda package instead
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        result = converter._compute_conda_dependencies([
             RequiresDistEntry.parse("uvicorn[standard] >=0.20")
         ])
     assert result == ["uvicorn >=0.20"]
     assert "Dropping extras [standard]" in caplog.text
-    assert "uvicorn[standard]" in caplog.text
+    assert "'uvicorn-standard'" in caplog.text
+    assert "--known-extras" in caplog.text
 
     # a rule matching the bracketed form maps the dependency
     # and suppresses the warning
@@ -1680,4 +1691,55 @@ def test_compute_dependencies_extras(caplog: pytest.LogCaptureFixture) -> None:
             RequiresDistEntry.parse("uvicorn[standard] >=0.20")
         ])
     assert result == []
+    assert "Dropping extras" not in caplog.text
+
+
+def test_compute_dependencies_known_extras(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """use_known_extras replaces known extras with conda packages (#217)"""
+    converter = Wheel2CondaConverter(Path("fake.whl"), Path("."))
+    converter.logger = logging.getLogger(__name__)
+    converter.use_known_extras = True
+
+    # known extra replaced by the corresponding conda package
+    with caplog.at_level(logging.WARNING):
+        result = converter._compute_conda_dependencies([
+            RequiresDistEntry.parse("uvicorn[standard] >=0.20")
+        ])
+    assert result == ["uvicorn-standard >=0.20"]
+    assert "Dropping extras" not in caplog.text
+
+    # multiple extras mapping to the same package are deduplicated
+    result = converter._compute_conda_dependencies([
+        RequiresDistEntry.parse("psycopg[binary,c] >=3.1")
+    ])
+    assert result == ["psycopg >=3.1"]
+
+    # each extra contributes its own package
+    result = converter._compute_conda_dependencies([
+        RequiresDistEntry.parse("ray[default, serve] >=2.9")
+    ])
+    assert result == ["ray-default >=2.9", "ray-serve >=2.9"]
+
+    # unknown extras keep the base package and still warn
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        result = converter._compute_conda_dependencies([
+            RequiresDistEntry.parse("ray[default,nosuchextra] >=2.9")
+        ])
+    # (the base package still goes through the standard renames)
+    assert result == ["ray-default >=2.9", "ray-core >=2.9"]
+    assert "Dropping extras [nosuchextra]" in caplog.text
+
+    # explicit rename rules take precedence over the known table
+    caplog.clear()
+    converter.dependency_rename = [
+        DependencyRename.from_strings(r"uvicorn\[standard\]", "my-uvicorn")
+    ]
+    with caplog.at_level(logging.WARNING):
+        result = converter._compute_conda_dependencies([
+            RequiresDistEntry.parse("uvicorn[standard] >=0.20")
+        ])
+    assert result == ["my-uvicorn >=0.20"]
     assert "Dropping extras" not in caplog.text

--- a/test/api/test_converter.py
+++ b/test/api/test_converter.py
@@ -1617,3 +1617,67 @@ def test_compute_conda_deps_name_normalization() -> None:
         RequiresDistEntry.parse("Acme.Internal_Pkg >=2.0")
     ])
     assert result == ["acme_internal >=2.0"]
+
+
+def test_compute_dependencies_extras(caplog: pytest.LogCaptureFixture) -> None:
+    """Dependencies with extras warn unless handled by a rename rule (#217)"""
+    converter = Wheel2CondaConverter(Path("fake.whl"), Path("."))
+    converter.logger = logging.getLogger(__name__)
+
+    # extras are dropped with a warning by default
+    with caplog.at_level(logging.WARNING):
+        result = converter._compute_conda_dependencies([
+            RequiresDistEntry.parse("uvicorn[standard] >=0.20")
+        ])
+    assert result == ["uvicorn >=0.20"]
+    assert "Dropping extras [standard]" in caplog.text
+    assert "uvicorn[standard]" in caplog.text
+
+    # a rule matching the bracketed form maps the dependency
+    # and suppresses the warning
+    caplog.clear()
+    converter.dependency_rename = [
+        DependencyRename.from_strings(r"dask\[complete\]", "dask")
+    ]
+    with caplog.at_level(logging.WARNING):
+        result = converter._compute_conda_dependencies([
+            RequiresDistEntry.parse("dask[complete] >=2024.1")
+        ])
+    assert result == ["dask >=2024.1"]
+    assert "Dropping extras" not in caplog.text
+
+    # multiple extras are matched in the order written
+    caplog.clear()
+    converter.dependency_rename = [
+        DependencyRename.from_strings(r"foo\[bar,baz\]", "foo-full")
+    ]
+    with caplog.at_level(logging.WARNING):
+        result = converter._compute_conda_dependencies([
+            RequiresDistEntry.parse("foo[bar, baz] >=1")
+        ])
+    assert result == ["foo-full >=1"]
+    assert "Dropping extras" not in caplog.text
+
+    # a bare-name rule still renames the base package but warns
+    caplog.clear()
+    converter.dependency_rename = [
+        DependencyRename.from_strings("uvicorn", "uvicorn-base")
+    ]
+    with caplog.at_level(logging.WARNING):
+        result = converter._compute_conda_dependencies([
+            RequiresDistEntry.parse("uvicorn[standard] >=0.20")
+        ])
+    assert result == ["uvicorn-base >=0.20"]
+    assert "Dropping extras [standard]" in caplog.text
+
+    # explicitly dropping the bracketed form is silent
+    caplog.clear()
+    converter.dependency_rename = [
+        DependencyRename.from_strings(r"uvicorn\[standard\]", "")
+    ]
+    with caplog.at_level(logging.WARNING):
+        result = converter._compute_conda_dependencies([
+            RequiresDistEntry.parse("uvicorn[standard] >=0.20")
+        ])
+    assert result == []
+    assert "Dropping extras" not in caplog.text

--- a/test/api/test_converter.py
+++ b/test/api/test_converter.py
@@ -1770,6 +1770,29 @@ FAKE_PYPI_METADATA: dict[tuple[str, str], dict[str, Any]] = {
             ],
         },
     },
+    ("loopy", ""): {
+        "info": {
+            "version": "1.0",
+            "provides_extra": ["x"],
+            "requires_dist": [
+                "loopdep >=1 ; extra == 'x'",
+                "loopy[x] >=1 ; extra == 'x'",
+                "???",
+            ],
+        },
+        "releases": {"1.0": [], "not-a-version": []},
+    },
+    ("multi", ""): {
+        "info": {
+            "version": "2.0",
+            "provides_extra": ["e1", "e2"],
+            "requires_dist": [
+                "dep-one >=1 ; extra == 'e1'",
+                "dep-two >=2 ; extra == 'e2'",
+            ],
+        },
+        "releases": {"2.0": []},
+    },
     ("fastapi", ""): {
         "info": {
             "version": "0.110.0",
@@ -1862,6 +1885,45 @@ def test_compute_dependencies_resolve_extras(
     assert result == ["somepkg >=1.0"]
     assert "Cannot fetch pypi metadata for 'somepkg'" in caplog.text
     assert "Dropping extras [fancy]" in caplog.text
+
+    # self-referential extras terminate; unparseable entries are skipped
+    caplog.clear()
+    monkeypatch.setattr("whl2conda.api.converter.fetch_pypi_metadata", fake_fetch)
+    converter._pypi_metadata_cache.clear()
+    with caplog.at_level(logging.WARNING):
+        result = converter._compute_conda_dependencies([
+            RequiresDistEntry.parse("loopy[x] >=1")
+        ])
+    assert result == ["loopy >=1", "loopdep >=1", "loopy >=1"]
+    assert "Dropping extras" not in caplog.text
+
+    # metadata for multiple extras of one package is fetched only once,
+    # and unparseable release versions are skipped in version selection
+    fetches.clear()
+    converter._pypi_metadata_cache.clear()
+    result = converter._compute_conda_dependencies([
+        RequiresDistEntry.parse("multi[e1,e2] >=1")
+    ])
+    assert result == ["multi >=1", "dep-one >=1", "dep-two >=2"]
+    assert fetches == [("multi", "")]
+
+    # a dependency without a version spec uses the latest metadata
+    fetches.clear()
+    converter._pypi_metadata_cache.clear()
+    result = converter._compute_conda_dependencies([
+        RequiresDistEntry.parse("multi[e2]")
+    ])
+    assert result == ["multi ", "dep-two >=2"]
+    assert fetches == [("multi", "")]
+
+    # when no release satisfies the spec, the latest metadata is used
+    fetches.clear()
+    converter._pypi_metadata_cache.clear()
+    result = converter._compute_conda_dependencies([
+        RequiresDistEntry.parse("multi[e1] >=99")
+    ])
+    assert result == ["multi >=99", "dep-one >=1"]
+    assert fetches == [("multi", "")]
 
     # known extras take precedence over pypi resolution when enabled
     fetches.clear()

--- a/test/api/validator.py
+++ b/test/api/validator.py
@@ -392,10 +392,18 @@ class PackageValidator:
             version = entry.version
             conda_version = cvt.translate_version_spec(version)
             renamed = False
-            for pat, template in self._renamed_dependencies.items():
-                if m := re.fullmatch(name, pat):
-                    name = m.expand(template)
-                    renamed = True
+            # rules are matched against the bracketed name[extra,...]
+            # form first, then the bare name - like the converter
+            match_names = [name]
+            if entry.extras:
+                match_names.insert(0, f"{name}[{','.join(entry.extras)}]")
+            for match_name in match_names:
+                for pat, template in self._renamed_dependencies.items():
+                    if m := re.fullmatch(pat, match_name):
+                        name = m.expand(template)
+                        renamed = True
+                        break
+                if renamed:
                     break
             if not renamed:
                 name = self._std_renames.get(name, name)

--- a/test/cli/test_convert.py
+++ b/test/cli/test_convert.py
@@ -88,6 +88,7 @@ class CliTestCase:
     expected_extra_dependencies: Sequence[str] = ()
     expected_for_conda_forge: bool = False
     expected_known_extras: bool = False
+    expected_resolve_extras: bool = False
     expected_interactive: bool = True
     expected_keep_pip: bool = False
     expected_out_dir: str = ""
@@ -134,6 +135,7 @@ class CliTestCase:
         expected_download_spec: str = "",
         expected_for_conda_forge: bool = False,
         expected_known_extras: bool = False,
+        expected_resolve_extras: bool = False,
         expected_interactive: bool = True,
         expected_keep_pip: bool = False,
         expected_out_dir: str = "",
@@ -164,6 +166,7 @@ class CliTestCase:
         self.expected_extra_dependencies = list(expected_extra_dependencies)
         self.expected_for_conda_forge = expected_for_conda_forge
         self.expected_known_extras = expected_known_extras
+        self.expected_resolve_extras = expected_resolve_extras
         self.expected_interactive = expected_interactive
         self.expected_keep_pip = expected_keep_pip
         self.expected_out_dir = expected_out_dir
@@ -346,6 +349,7 @@ class CliTestCase:
         assert converter.keep_pip_dependencies is self.expected_keep_pip
         assert converter.for_conda_forge is self.expected_for_conda_forge
         assert converter.use_known_extras is self.expected_known_extras
+        assert converter.resolve_extras is self.expected_resolve_extras
         assert converter.platform_tag == self.expected_platform_tag
         assert converter.extra_dependencies == list(self.expected_extra_dependencies)
         assert converter.dependency_rename == list(self.expected_dependency_renames)
@@ -410,6 +414,7 @@ class CliTestCaseFactory:
         expected_extra_dependencies: Sequence[str] = (),
         expected_for_conda_forge: bool = False,
         expected_known_extras: bool = False,
+        expected_resolve_extras: bool = False,
         expected_interactive: bool = True,
         expected_project_root: str = "",
         expected_python_version: str = "",
@@ -440,6 +445,7 @@ class CliTestCaseFactory:
             expected_extra_dependencies=expected_extra_dependencies,
             expected_for_conda_forge=expected_for_conda_forge,
             expected_known_extras=expected_known_extras,
+            expected_resolve_extras=expected_resolve_extras,
             expected_interactive=expected_interactive,
             expected_project_root=expected_project_root,
             expected_python_version=expected_python_version,
@@ -1028,6 +1034,9 @@ def test_known_extras(
     """--known-extras enables known extras replacement"""
     test_case([str(simple_wheel)]).run()
     test_case([str(simple_wheel), "--known-extras"], expected_known_extras=True).run()
+    test_case(
+        [str(simple_wheel), "--resolve-extras"], expected_resolve_extras=True
+    ).run()
 
 
 def test_allow_metadata_version(

--- a/test/cli/test_convert.py
+++ b/test/cli/test_convert.py
@@ -87,6 +87,7 @@ class CliTestCase:
     expected_dry_run: bool = False
     expected_extra_dependencies: Sequence[str] = ()
     expected_for_conda_forge: bool = False
+    expected_known_extras: bool = False
     expected_interactive: bool = True
     expected_keep_pip: bool = False
     expected_out_dir: str = ""
@@ -132,6 +133,7 @@ class CliTestCase:
         expected_download_index: str = "",
         expected_download_spec: str = "",
         expected_for_conda_forge: bool = False,
+        expected_known_extras: bool = False,
         expected_interactive: bool = True,
         expected_keep_pip: bool = False,
         expected_out_dir: str = "",
@@ -161,6 +163,7 @@ class CliTestCase:
         self.expected_download_spec = expected_download_spec
         self.expected_extra_dependencies = list(expected_extra_dependencies)
         self.expected_for_conda_forge = expected_for_conda_forge
+        self.expected_known_extras = expected_known_extras
         self.expected_interactive = expected_interactive
         self.expected_keep_pip = expected_keep_pip
         self.expected_out_dir = expected_out_dir
@@ -342,6 +345,7 @@ class CliTestCase:
         assert converter.overwrite is self.expected_overwrite
         assert converter.keep_pip_dependencies is self.expected_keep_pip
         assert converter.for_conda_forge is self.expected_for_conda_forge
+        assert converter.use_known_extras is self.expected_known_extras
         assert converter.platform_tag == self.expected_platform_tag
         assert converter.extra_dependencies == list(self.expected_extra_dependencies)
         assert converter.dependency_rename == list(self.expected_dependency_renames)
@@ -405,6 +409,7 @@ class CliTestCaseFactory:
         expected_keep_pip: bool = False,
         expected_extra_dependencies: Sequence[str] = (),
         expected_for_conda_forge: bool = False,
+        expected_known_extras: bool = False,
         expected_interactive: bool = True,
         expected_project_root: str = "",
         expected_python_version: str = "",
@@ -434,6 +439,7 @@ class CliTestCaseFactory:
             expected_keep_pip=expected_keep_pip,
             expected_extra_dependencies=expected_extra_dependencies,
             expected_for_conda_forge=expected_for_conda_forge,
+            expected_known_extras=expected_known_extras,
             expected_interactive=expected_interactive,
             expected_project_root=expected_project_root,
             expected_python_version=expected_python_version,
@@ -1013,6 +1019,15 @@ def test_for_conda_forge(
         [str(simple_wheel), "--for-conda-forge"], expected_for_conda_forge=True
     ).run()
     test_case([str(simple_wheel), "--for-cpython"], expected_for_conda_forge=True).run()
+
+
+def test_known_extras(
+    test_case: CliTestCaseFactory,
+    simple_wheel: Path,
+) -> None:
+    """--known-extras enables known extras replacement"""
+    test_case([str(simple_wheel)]).run()
+    test_case([str(simple_wheel), "--known-extras"], expected_known_extras=True).run()
 
 
 def test_allow_metadata_version(

--- a/test/impl/test_download.py
+++ b/test/impl/test_download.py
@@ -216,3 +216,27 @@ def test_download(tmp_path: Path) -> None:
             pytest.skip("Cannot connect to pypi index ")
         else:
             raise
+
+
+def test_fetch_pypi_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Whitebox test of fetch_pypi_metadata"""
+    import io
+    import json
+    from contextlib import closing
+
+    from whl2conda.impl.download import fetch_pypi_metadata
+
+    urls: list[str] = []
+
+    def fake_urlopen(url: str, timeout: float = 0):
+        urls.append(url)
+        return closing(io.BytesIO(json.dumps({"info": {"name": "foo"}}).encode()))
+
+    monkeypatch.setattr("whl2conda.impl.download.urllib.request.urlopen", fake_urlopen)
+
+    data = fetch_pypi_metadata("foo")
+    assert data == {"info": {"name": "foo"}}
+    assert urls == ["https://pypi.org/pypi/foo/json"]
+
+    fetch_pypi_metadata("foo", "1.2.3")
+    assert urls[-1] == "https://pypi.org/pypi/foo/1.2.3/json"


### PR DESCRIPTION
Implements the full non-CEP scope of extras handling. Closes #217, closes #36 (the long-term matchspec translation is now tracked by #219).

Previously, dependencies of the form `name[extra,...]` had their brackets **silently** stripped: `uvicorn[standard] >=0.20` became `uvicorn >=0.20` and the extra's dependencies were lost with no indication. This PR makes extras handling explicit and layered — each tier is tried in order:

1. **Explicit rename rules** are matched against the bracketed `name[extra,...]` form before the bare name, so a dependency with extras can be mapped to a conda metapackage: `-R 'dask\[complete\]' dask -R dask dask-core`. A bracketed match (including an explicit drop) is authoritative.

2. **Built-in known-extras table** (`--known-extras`): common extras with dedicated conda-forge packages — `black[jupyter]`, `dask[complete]`, the 15 `ibis-framework` backend extras, `psycopg[binary]/[c]`, the 9 `ray` extras, `uvicorn[standard]` — every entry verified to exist on conda-forge and to version-track/subsume the base package (which is why e.g. `psycopg-pool` is excluded: independent versioning). Even without the option, the warning names the corresponding conda package, since most users won't know these exist.

3. **PyPI metadata resolution** (`--resolve-extras`): remaining extras are expanded from pypi.org metadata — the extra's dependencies are read from the newest release satisfying the dependency's version spec, converted like regular dependencies (with marker evaluation), and nested extras (`fastapi[all]` → `uvicorn[standard]`) resolve recursively with cycle protection. Documented as best-effort due to version skew; fetch failures degrade gracefully to the warning.

4. **Warning**: anything still unhandled warns with the dependency, its extras, and the applicable remedies, instead of silently dropping.

Also:
- New runtime dependency on `packaging` (for release selection; it was already used opportunistically for marker evaluation), and a `fetch_pypi_metadata` helper in `impl/download.py`.
- The test validator mirrors the bracketed-form rename matching (and a latent bug is fixed: its `re.fullmatch` arguments were swapped).
- New "Dependencies with extras" section in the renaming guide; changelog entries under the in-progress section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)