### PR TITLE
Support package test specification in pyproject.toml (#190)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@
   `--mamba` uses mamba to create test environments and to run
   conda-build when it must be run in the base environment. (#110)
 
+* Package tests for the generated conda package can now be specified
+  in `[[tool.whl2conda.tests]]` in pyproject.toml, using the v1 recipe
+  `tests` schema, or in a standalone YAML file; the new
+  `tool.whl2conda.test-python` option lists python versions to test
+  against. (#190)
+
 ### Changes
 
 * `whl2conda build` renders recipes into its own temporary work

--- a/doc/guide/pyproject.md
+++ b/doc/guide/pyproject.md
@@ -75,4 +75,38 @@ For example, to rename all `acme-<foo>` packages to `acme.<foo>`:
 
 An optional list of extra conda dependencies.
 
+### tests
+
+An optional list of package tests, using the
+[v1 recipe `tests` schema][v1-tests] used by rattler-build, so a test
+list can be copied verbatim between this section and a `recipe.yaml`
+file. For example:
+
+```toml
+[[tool.whl2conda.tests]]
+python = { imports = ["widget"], pip_check = true }
+
+[[tool.whl2conda.tests]]
+script = ["pytest test"]
+requirements = { run = ["pytest >=7"] }
+files = { source = ["test", "conftest.py"] }
+```
+
+The supported test elements are `python` tests (`imports` and
+`pip_check`) and `script` tests (commands with optional
+`requirements.run` dependencies and `files.source` files, which are
+resolved relative to the project directory). Unlike rattler-build,
+all test elements are run in a single shared test environment.
+
+These tests are run by the `whl2conda test` command against a
+generated conda package.
+
+### test-python
+
+An optional list of python versions (e.g. `["3.10", "3.14"]`) against
+which the package tests are run, once per version. If empty, a single
+test environment is created letting the solver choose the python
+version.
+
 [poetry-pyproject]: https://python-poetry.org/docs/pyproject/
+[v1-tests]: https://rattler-build.prefix.dev/latest/reference/recipe_file/#tests-section

--- a/src/whl2conda/cli/testenv.py
+++ b/src/whl2conda/cli/testenv.py
@@ -33,6 +33,9 @@ from itertools import chain
 from pathlib import Path
 from typing import Any
 
+# third party
+import yaml
+
 # this project
 from .install import install_main
 
@@ -132,6 +135,31 @@ class PackageTestSpec:
             pip_check=pip_check,
         )
 
+    @classmethod
+    def from_file(cls, path: Path) -> PackageTestSpec:
+        """Load spec from a YAML file containing a v1 recipe `tests` list.
+
+        The file may contain either a bare list of test elements or a
+        mapping with a `tests` key (e.g. an excerpt from a recipe.yaml).
+
+        Raises:
+            PackageTestError: if the file cannot be parsed as a v1
+                `tests` list.
+        """
+        try:
+            data = yaml.safe_load(path.read_text("utf8"))
+        except (OSError, yaml.YAMLError) as ex:
+            raise PackageTestError(f"Cannot read test file {path}: {ex}") from ex
+        if isinstance(data, Mapping):
+            data = data.get("tests")
+        if not isinstance(data, list) or not all(
+            isinstance(entry, Mapping) for entry in data
+        ):
+            raise PackageTestError(
+                f"Test file {path} does not contain a v1 recipe `tests` list"
+            )
+        return cls.from_v1_tests(data)
+
 
 def run_package_tests(
     package: Path,
@@ -143,6 +171,7 @@ def run_package_tests(
     channels: Sequence[str] = (),
     keep_env: bool = False,
     use_mamba: bool = False,
+    python_version: str = "",
 ) -> None:
     """Install a conda package into a fresh environment and test it.
 
@@ -158,6 +187,8 @@ def run_package_tests(
         keep_env: do not remove the test environment afterwards
         use_mamba: use mamba instead of conda to create the test
             environment and run the tests
+        python_version: python version for the test environment, e.g.
+            "3.10"; when empty, the solver chooses
 
     Raises:
         PackageTestError: if a test fails or cannot be run.
@@ -176,6 +207,7 @@ def run_package_tests(
             # channels must come after the package specs, since conda's
             # parser does not accept specs following a -c option
             *spec.requires,
+            *([f"python={python_version}"] if python_version else []),
             *chain.from_iterable(("-c", channel) for channel in channels),
         ]
         install_main(install_cmd)

--- a/src/whl2conda/impl/pyproject.py
+++ b/src/whl2conda/impl/pyproject.py
@@ -327,7 +327,8 @@ def read_pyproject(path: Path) -> PyProjInfo:
                     # unwrap to plain python containers/strings, since
                     # tomlkit str subclasses do not survive e.g. Path.glob
                     _tests.append(entry.unwrap())
-                elif isinstance(entry, Mapping):
+                elif isinstance(entry, Mapping):  # pragma: no cover
+                    # unreachable via tomlkit, which always yields Items
                     _tests.append(entry)
                 else:
                     warn_ignored_value(

--- a/src/whl2conda/impl/pyproject.py
+++ b/src/whl2conda/impl/pyproject.py
@@ -26,6 +26,7 @@ from pathlib import Path
 from typing import Any
 
 import tomlkit
+from tomlkit.items import Item
 
 __all__ = [
     "CondaPackageFormat",
@@ -322,10 +323,12 @@ def read_pyproject(path: Path) -> PyProjInfo:
         if isinstance(tests, Sequence) and not isinstance(tests, str):
             _tests: list[Mapping[str, Any]] = []
             for entry in tests:
-                if isinstance(entry, Mapping):
+                if isinstance(entry, Item) and isinstance(entry, Mapping):
                     # unwrap to plain python containers/strings, since
                     # tomlkit str subclasses do not survive e.g. Path.glob
-                    _tests.append(entry.unwrap() if hasattr(entry, "unwrap") else entry)
+                    _tests.append(entry.unwrap())
+                elif isinstance(entry, Mapping):
+                    _tests.append(entry)
                 else:
                     warn_ignored_value(
                         toml_file, "tests", f"Expected table but got '{entry}'"

--- a/src/whl2conda/impl/pyproject.py
+++ b/src/whl2conda/impl/pyproject.py
@@ -323,7 +323,9 @@ def read_pyproject(path: Path) -> PyProjInfo:
             _tests: list[Mapping[str, Any]] = []
             for entry in tests:
                 if isinstance(entry, Mapping):
-                    _tests.append(entry)
+                    # unwrap to plain python containers/strings, since
+                    # tomlkit str subclasses do not survive e.g. Path.glob
+                    _tests.append(entry.unwrap() if hasattr(entry, "unwrap") else entry)
                 else:
                     warn_ignored_value(
                         toml_file, "tests", f"Expected table but got '{entry}'"
@@ -341,7 +343,7 @@ def read_pyproject(path: Path) -> PyProjInfo:
         if isinstance(test_python, Sequence):
             for version in test_python:
                 if isinstance(version, str):
-                    _test_python.append(version)
+                    _test_python.append(str(version))
                 else:
                     warn_ignored_value(
                         toml_file,

--- a/src/whl2conda/impl/pyproject.py
+++ b/src/whl2conda/impl/pyproject.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import enum
 import warnings
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -109,6 +109,20 @@ class PyProjInfo:
     """tool.whl2conda.extra-dependencies - additional conda dependencies
     """
 
+    tests: Sequence[Mapping[str, Any]] = ()
+    """tool.whl2conda.tests - package tests for the generated conda package
+
+    This is a list of test elements using the v1 recipe `tests` schema
+    (CEP 13/14), as used by rattler-build.
+    """
+
+    test_python: Sequence[str] = ()
+    """tool.whl2conda.test-python - python versions for test environments
+
+    Package tests are run once per listed version. When empty, a single
+    test environment is created letting the solver choose the version.
+    """
+
 
 def warn_ignored_key(file: Path, key: str, msg: str) -> None:
     """Warn about ignored key in pyproject.toml config"""
@@ -174,6 +188,15 @@ TOOL_DEFAULTS = {
     "extra-dependencies": {
         "default": [],
         "comment": ["An optional list of extra conda dependencies."],
+    },
+    "test-python": {
+        "default": [],
+        "comment": [
+            "An optional list of python versions (e.g. [\"3.10\", \"3.14\"])",
+            "against which package tests are run, once per version.",
+            "If empty, a single test environment is created letting the",
+            "solver choose the python version.",
+        ],
     },
 }
 
@@ -294,6 +317,42 @@ def read_pyproject(path: Path) -> PyProjInfo:
                     toml_file, "extra-dependencies", f"Expected string but got '{dep}'"
                 )
         pyproj.extra_dependencies = tuple(_extra_deps)
+
+    if tests := whl2conda.get("tests", ()):
+        if isinstance(tests, Sequence) and not isinstance(tests, str):
+            _tests: list[Mapping[str, Any]] = []
+            for entry in tests:
+                if isinstance(entry, Mapping):
+                    _tests.append(entry)
+                else:
+                    warn_ignored_value(
+                        toml_file, "tests", f"Expected table but got '{entry}'"
+                    )
+            pyproj.tests = tuple(_tests)
+        else:
+            warn_ignored_key(
+                toml_file, "tests", f"value is not a list of tables: {tests}"
+            )
+
+    if test_python := whl2conda.get("test-python", ()):
+        if isinstance(test_python, str):
+            test_python = [test_python]
+        _test_python: list[str] = []
+        if isinstance(test_python, Sequence):
+            for version in test_python:
+                if isinstance(version, str):
+                    _test_python.append(version)
+                else:
+                    warn_ignored_value(
+                        toml_file,
+                        "test-python",
+                        f"Expected string (e.g. \"3.10\") but got '{version}'",
+                    )
+            pyproj.test_python = tuple(_test_python)
+        else:
+            warn_ignored_key(
+                toml_file, "test-python", f"value is not a list: {test_python}"
+            )
 
     if conda_format := _read_str("conda-format", whl2conda):
         try:

--- a/test/cli/test_testenv.py
+++ b/test/cli/test_testenv.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import shutil
 import subprocess
 from pathlib import Path
+from textwrap import dedent
 from typing import Any
 
 import pytest
@@ -353,3 +354,65 @@ def test_build_test_adapter(
     # empty test section: runner is not invoked
     builder._run_package_tests(pkg, make_rendered({}))
     assert len(calls) == 5
+
+
+def test_spec_from_file(tmp_path: Path) -> None:
+    """Spec loaded from a YAML file with a v1 tests list"""
+    test_file = tmp_path / "tests.yaml"
+
+    # bare list form
+    test_file.write_text(
+        dedent("""
+            - python:
+                imports: [foo]
+                pip_check: false
+            - script: pytest test
+              requirements:
+                run: ["pytest >=7"]
+            """)
+    )
+    spec = PackageTestSpec.from_file(test_file)
+    assert spec.imports == ("foo",)
+    assert spec.commands == ("pytest test",)
+    assert spec.requires == ("pytest >=7",)
+
+    # recipe.yaml excerpt form with a `tests` key
+    test_file.write_text(
+        dedent("""
+            tests:
+              - python:
+                  imports: [foo]
+            """)
+    )
+    spec = PackageTestSpec.from_file(test_file)
+    assert spec.imports == ("foo",)
+
+    # bad contents
+    test_file.write_text("just a string")
+    with pytest.raises(PackageTestError, match="does not contain"):
+        PackageTestSpec.from_file(test_file)
+    test_file.write_text("tests:\n  - not-a-table")
+    with pytest.raises(PackageTestError, match="does not contain"):
+        PackageTestSpec.from_file(test_file)
+    with pytest.raises(PackageTestError, match="Cannot read"):
+        PackageTestSpec.from_file(tmp_path / "no-such-file.yaml")
+
+
+def test_run_package_tests_python_version(
+    fake_runner: FakeRunner, tmp_path: Path
+) -> None:
+    """python_version adds a python spec to the test environment"""
+    prefix = tmp_path / "env"
+    prefix.mkdir()
+    run_package_tests(
+        tmp_path / "foo.conda",
+        PackageTestSpec(requires=("pytest",), imports=("foo",)),
+        env_prefix=prefix,
+        work_dir=tmp_path / "work",
+        channels=["chan"],
+        python_version="3.12",
+    )
+    install_args = fake_runner.install_args[0]
+    # python spec comes after requires and before the channel options
+    extra = install_args[install_args.index("--extra") + 1 :]
+    assert extra == ["pytest", "python=3.12", "-c", "chan"]

--- a/test/impl/test_pyproject.py
+++ b/test/impl/test_pyproject.py
@@ -255,3 +255,79 @@ def test_add_pyproject_defaults(tmp_path: Path, capsys: pytest.CaptureFixture) -
 
     with pytest.raises(ValueError):
         add_pyproject_defaults("foo.not-toml")
+
+
+def test_read_pyproject_tests(tmp_path: Path) -> None:
+    """Parsing of tool.whl2conda.tests and test-python (#190)"""
+    proj_file = tmp_path.joinpath("pyproject.toml")
+    proj_file.write_text(
+        dedent(r"""
+            [project]
+            name = "widget"
+
+            [tool.whl2conda]
+            test-python = ["3.10", "3.14"]
+
+            [[tool.whl2conda.tests]]
+            python = { imports = ["widget"], pip_check = true }
+
+            [[tool.whl2conda.tests]]
+            script = ["pytest test"]
+            requirements = { run = ["pytest >=7"] }
+            files = { source = ["test", "conftest.py"] }
+            """),
+        encoding="ascii",
+    )
+    pyproj = read_pyproject(tmp_path)
+    assert len(pyproj.tests) == 2
+    assert pyproj.tests[0]["python"]["imports"] == ["widget"]
+    assert pyproj.test_python == ("3.10", "3.14")
+
+    # the parsed tests convert directly into a test spec
+    from whl2conda.cli.testenv import PackageTestSpec
+
+    spec = PackageTestSpec.from_v1_tests(pyproj.tests)
+    assert spec.imports == ("widget",)
+    assert spec.pip_check
+    assert spec.commands == ("pytest test",)
+    assert spec.requires == ("pytest >=7", "pip")
+    assert spec.source_files == ("test", "conftest.py")
+
+    # a single test-python string is accepted
+    proj_file.write_text(
+        dedent(r"""
+            [tool.whl2conda]
+            test-python = "3.12"
+            """),
+        encoding="ascii",
+    )
+    assert read_pyproject(tmp_path).test_python == ("3.12",)
+
+    # bad values are warned about and ignored
+    proj_file.write_text(
+        dedent(r"""
+            [tool.whl2conda]
+            tests = "not-a-list"
+            test-python = [3.10]
+            """),
+        encoding="ascii",
+    )
+    with pytest.warns(UserWarning, match="Ignoring") as warnings:
+        pyproj = read_pyproject(tmp_path)
+    assert not pyproj.tests
+    assert not pyproj.test_python
+    messages = "\n".join(str(w.message) for w in warnings)
+    assert "tests" in messages
+    assert "test-python" in messages
+
+    # non-table test entries are dropped individually
+    proj_file.write_text(
+        dedent(r"""
+            [tool.whl2conda]
+            tests = ["bad", { script = "pytest" }]
+            """),
+        encoding="ascii",
+    )
+    with pytest.warns(UserWarning, match="Expected table"):
+        pyproj = read_pyproject(tmp_path)
+    assert len(pyproj.tests) == 1

--- a/test/impl/test_pyproject.py
+++ b/test/impl/test_pyproject.py
@@ -288,6 +288,10 @@ def test_read_pyproject_tests(tmp_path: Path) -> None:
 
     spec = PackageTestSpec.from_v1_tests(pyproj.tests)
     assert spec.imports == ("widget",)
+    # values are plain python strings, not tomlkit subclasses,
+    # which e.g. Path.glob rejects on python 3.10
+    assert all(type(f) is str for f in spec.source_files)
+    assert all(type(v) is str for v in read_pyproject(tmp_path).test_python)
     assert spec.pip_check
     assert spec.commands == ("pytest test",)
     assert spec.requires == ("pytest >=7", "pip")

--- a/test/impl/test_pyproject.py
+++ b/test/impl/test_pyproject.py
@@ -316,6 +316,18 @@ def test_read_pyproject_tests(tmp_path: Path) -> None:
             """),
         encoding="ascii",
     )
+    with pytest.warns(UserWarning, match="Ignoring"):
+        assert not read_pyproject(tmp_path).test_python
+
+    # non-list test-python is also warned about and ignored
+    proj_file.write_text(
+        dedent(r"""
+            [tool.whl2conda]
+            tests = "not-a-list"
+            test-python = 3.10
+            """),
+        encoding="ascii",
+    )
     with pytest.warns(UserWarning, match="Ignoring") as warnings:
         pyproj = read_pyproject(tmp_path)
     assert not pyproj.tests


### PR DESCRIPTION
First of two PRs implementing the design proposal in https://github.com/zuzukin/whl2conda/issues/190#issuecomment-4951872045 (stacked on #214; targeted at the same release as the build support).

- **`[[tool.whl2conda.tests]]`** array of tables using the v1 recipe `tests` schema — parsed into `PyProjInfo.tests` with the usual warn-and-ignore handling for malformed entries, and consumable directly by `PackageTestSpec.from_v1_tests()`, so a tests list is copy-paste compatible with `recipe.yaml` in both directions.
- **`tool.whl2conda.test-python`** — list of python versions to test against (single string accepted); deliberately outside the v1-schema block to keep it copy-paste clean. Float values like `3.10` are rejected with a warning telling the user to quote (TOML would truncate `3.10` to `3.1`).
- **`PackageTestSpec.from_file()`** — loads a v1 tests list from a standalone YAML file (bare list or a `tests:` mapping excerpt), for testing foreign wheels with no pyproject.
- **`run_package_tests(python_version=...)`** — appends a `python=X.Y` spec at environment creation, positioned with the package specs before the channel options.
- New "tests"/"test-python" sections in the pyproject guide; `--generate-pyproject` emits a commented `test-python` default.

The `whl2conda test` subcommand (#83) that consumes all of this follows in the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)