### PR TITLE
Add whl2conda test command (#83)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@
   `tool.whl2conda.test-python` option lists python versions to test
   against. (#190)
 
+* New `whl2conda test` command tests a conda package file in a fresh
+  environment, using tests from a `--test-file` YAML file, the
+  pyproject.toml `[tool.whl2conda.tests]` section, or the test section
+  of a conda recipe, optionally against multiple python versions. (#83)
+
 ### Changes
 
 * `whl2conda build` renders recipes into its own temporary work

--- a/doc/guide/testing.md
+++ b/doc/guide/testing.md
@@ -31,6 +31,50 @@ them in a single install command, e.g.:
 $ whl2conda install mypackage-1.2.3-py_0.conda mycorepackage-1.2.3-py_0.conda ...
 ```
 
+## Running package tests
+
+The `whl2conda test` command automates the install-and-test cycle:
+it creates a fresh environment, installs the package and any test
+requirements into it, runs the specified tests, and removes the
+environment:
+
+```bash
+$ whl2conda test dist/mypackage-1.2.3-py_0.conda
+```
+
+The tests are taken from, in order of precedence:
+
+* a YAML file given with `--test-file`, containing a v1 recipe
+  `tests` list (either a bare list or a mapping with a `tests` key),
+* the `[[tool.whl2conda.tests]]` section of the project's
+  `pyproject.toml` (see [the pyproject guide](pyproject.md#tests)), or
+* the test section of a conda recipe (`meta.yaml` or `recipe.yaml`)
+  in the project directory, which will be rendered first.
+
+The project directory defaults to the current directory and may be
+given as a second argument:
+
+```bash
+$ whl2conda test dist/mypackage-1.2.3-py_0.conda conda.recipe
+```
+
+To test against specific python versions (for example, to check the
+boundaries of a `noarch: python` package's python requirement), use
+one or more `--python` options, or the `test-python` setting in
+`pyproject.toml`; the tests are run once per version:
+
+```bash
+$ whl2conda test dist/mypackage-1.2.3-py_0.conda --python 3.10 --python 3.14
+```
+
+Additional channels for the test environment can be supplied with
+`-c`/`--channel`, `--keep-test-env` retains the environment for
+debugging, and `--dry-run` shows the tests that would be run. The
+command exits with a non-zero status if any test fails, so it can be
+used in scripts and CI. See the
+[command reference](../reference/cli/whl2conda-test.md) for all
+options.
+
 ## Installing into conda-bld
 
 Once you are done testing, you may upload your package to a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -436,6 +436,9 @@ preview = true
 explicit-preview-rules = true
 
 [tool.ruff.lint.per-file-ignores]
+# pytest-style rules do not apply to the package itself (e.g. the
+# whl2conda test command module is not a pytest test module)
+"src/**" = ["PT"]
 "test/**" = [
     "F811",    # pytest fixture redefinitions
     "PLC0415", # tests may use function-local imports

--- a/src/whl2conda/cli/build.py
+++ b/src/whl2conda/cli/build.py
@@ -40,6 +40,7 @@ from ..impl.recipe import (
     RecipeError,
     RecipeFormat,
     RenderedRecipe,
+    recipe_source_root,
     render_recipe,
     rewrite_build_script,
 )
@@ -533,26 +534,8 @@ class CondaBuild:
         return predict_package_path(rendered, bld_path, fmt)
 
     def _source_root(self, rendered: RenderedRecipe) -> Path:
-        """Directory containing the project source for this recipe.
-
-        This is the source copy in conda-build's work directory when it
-        exists, otherwise the recipe's local `path:` source when it has
-        one, and otherwise the current directory.
-        """
-        for work_src in sorted(self.work_dir.glob("croot/*/work")):
-            # conda-build only populates the work dir when the recipe
-            # needs the source at render time
-            if any(work_src.iterdir()):
-                return work_src
-        sources = rendered.raw.get("source") or ()
-        if isinstance(sources, dict):
-            sources = (sources,)
-        for source in sources:
-            if isinstance(source, dict) and (path := source.get("path")):
-                source_root = (rendered.recipe_dir / str(path)).resolve()
-                if source_root.is_dir():
-                    return source_root
-        return Path.cwd()
+        """Directory containing the project source for this recipe."""
+        return recipe_source_root(rendered, self.work_dir)
 
     def _build_wheel(self, dist_dir: Path, source_root: Path) -> Path:
         for line in self.build_script:

--- a/src/whl2conda/cli/main.py
+++ b/src/whl2conda/cli/main.py
@@ -72,6 +72,11 @@ def main(args: Sequence[str] | None = None, prog: str | None = None) -> None:
         "whl2conda.cli.install.install_main",
         "install conda package file with dependencies",
     )
+    subcmds.add_subcommand(
+        "test",
+        "whl2conda.cli.test.test_main",
+        "test conda package file in a fresh environment",
+    )
     # TODO subcommand for clean/fixup of conda-bld or pkgs cache
 
     class ListSubcommands(argparse.Action):

--- a/src/whl2conda/cli/test.py
+++ b/src/whl2conda/cli/test.py
@@ -265,8 +265,7 @@ def _resolve_test_spec(
         return spec, project_dir.absolute(), pyproj.test_python
 
     if not any(
-        project_dir.joinpath(name).is_file()
-        for name in ("meta.yaml", "recipe.yaml")
+        project_dir.joinpath(name).is_file() for name in ("meta.yaml", "recipe.yaml")
     ):
         return PackageTestSpec(), project_dir.absolute(), ()
 

--- a/src/whl2conda/cli/test.py
+++ b/src/whl2conda/cli/test.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """
-whl2conda test implementation (#83)
+whl2conda test implementation
 """
 
 from __future__ import annotations
@@ -31,7 +31,6 @@ from pathlib import Path
 from ..impl.pyproject import PyProjInfo, read_pyproject
 from ..impl.recipe import (
     RecipeError,
-    RenderedRecipe,
     recipe_source_root,
     render_recipe,
 )
@@ -81,13 +80,13 @@ def _create_argparser(prog: str | None = None) -> argparse.ArgumentParser:
 
     parser.add_argument(
         "package_file",
-        metavar="PACKAGE_FILE",
+        metavar="<package-file>",
         type=existing_path,
         help="Conda package file (.conda or .tar.bz2) to test",
     )
     parser.add_argument(
         "project_dir",
-        metavar="PROJECT_DIR",
+        metavar="<project-dir>",
         nargs="?",
         default=Path.cwd(),
         type=existing_dir,
@@ -213,7 +212,9 @@ def test_main(
         python_versions: Sequence[str] = testargs.python or project_python or [""]
 
         if testargs.dry_run:
-            _show_spec(spec, python_versions)
+            versions = ", ".join(v for v in python_versions if v) or "<default>"
+            print(f"python versions: {versions}")
+            print(spec.describe())
             return
 
         for python_version in python_versions:
@@ -272,36 +273,5 @@ def _resolve_test_spec(
     rendered = render_recipe(
         project_dir, work_dir=work_dir, use_mamba=testargs.use_mamba
     )
-    spec = _spec_from_recipe(rendered)
+    spec = PackageTestSpec.from_rendered_recipe(rendered)
     return spec, recipe_source_root(rendered, work_dir), pyproj.test_python
-
-
-def _spec_from_recipe(rendered: RenderedRecipe) -> PackageTestSpec:
-    """Extract the test spec from a rendered recipe."""
-    if tests := rendered.raw.get("tests"):
-        return PackageTestSpec.from_v1_tests(tests)
-    return PackageTestSpec.from_meta_yaml(rendered.raw.get("test") or {})
-
-
-def _show_spec(spec: PackageTestSpec, python_versions: Sequence[str]) -> None:
-    """Display the resolved test spec for --dry-run."""
-    versions = ", ".join(v for v in python_versions if v) or "<default>"
-    print(f"python versions: {versions}")
-    if spec.requires:
-        print("requires:")
-        for requirement in spec.requires:
-            print(f"  {requirement}")
-    if spec.source_files:
-        print("source files:")
-        for pattern in spec.source_files:
-            print(f"  {pattern}")
-    if spec.imports:
-        print("imports:")
-        for import_name in spec.imports:
-            print(f"  {import_name}")
-    if spec.pip_check:
-        print("pip check")
-    if spec.commands:
-        print("commands:")
-        for command in spec.commands:
-            print(f"  {command}")

--- a/src/whl2conda/cli/test.py
+++ b/src/whl2conda/cli/test.py
@@ -1,0 +1,308 @@
+#  Copyright 2026 Christopher Barber
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+whl2conda test implementation (#83)
+"""
+
+from __future__ import annotations
+
+# standard
+import argparse
+import dataclasses
+import logging
+import shutil
+import sys
+import tempfile
+from collections.abc import Sequence
+from pathlib import Path
+
+# this project
+from ..impl.pyproject import PyProjInfo, read_pyproject
+from ..impl.recipe import (
+    RecipeError,
+    RenderedRecipe,
+    recipe_source_root,
+    render_recipe,
+)
+from .common import add_markdown_help, dedent, existing_dir, existing_path
+from .testenv import PackageTestError, PackageTestSpec, run_package_tests
+
+__all__ = ["test_main"]
+
+logger = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass(slots=True)
+class TestArgs:
+    """Parsed arguments for whl2conda test"""
+
+    package_file: Path
+    project_dir: Path
+    channels: list[str]
+    debug: bool
+    dry_run: bool
+    keep_test_env: bool
+    prefix: Path | None
+    python: list[str]
+    quiet: int
+    test_file: Path | None
+    use_mamba: bool
+
+
+def _create_argparser(prog: str | None = None) -> argparse.ArgumentParser:
+    """Create the argument parser for whl2conda test."""
+    parser = argparse.ArgumentParser(
+        usage="%(prog)s <package-file> [<project-dir>] [options]",
+        description=dedent("""
+            Test a conda package file in a fresh conda environment.
+
+            Installs the package into a new environment (along with any
+            test requirements) and runs the tests specified by, in order
+            of precedence: the --test-file option, the
+            [tool.whl2conda.tests] section of a pyproject.toml, or the
+            test section of a conda recipe (meta.yaml or recipe.yaml)
+            found in the project directory.
+            """),
+        formatter_class=argparse.RawTextHelpFormatter,
+        prog=prog,
+        allow_abbrev=False,
+    )
+
+    parser.add_argument(
+        "package_file",
+        metavar="PACKAGE_FILE",
+        type=existing_path,
+        help="Conda package file (.conda or .tar.bz2) to test",
+    )
+    parser.add_argument(
+        "project_dir",
+        metavar="PROJECT_DIR",
+        nargs="?",
+        default=Path.cwd(),
+        type=existing_dir,
+        help=dedent("""
+            Directory containing the test specification: either a
+            pyproject.toml with a [tool.whl2conda.tests] section or a
+            conda recipe. Defaults to the current directory.
+            """),
+    )
+
+    test_opts = parser.add_argument_group("test options")
+    test_opts.add_argument(
+        "--test-file",
+        metavar="<yaml-file>",
+        type=existing_path,
+        help=dedent("""
+            Read tests from given YAML file containing a v1 recipe
+            `tests` list (either a bare list or a mapping with a
+            `tests` key), overriding any project test specification.
+            """),
+    )
+    test_opts.add_argument(
+        "-c",
+        "--channel",
+        action="append",
+        dest="channels",
+        default=[],
+        metavar="<channel>",
+        help="Additional channel for the test environment. May be repeated.",
+    )
+    test_opts.add_argument(
+        "--python",
+        action="append",
+        default=[],
+        metavar="<version>",
+        help=dedent("""
+            Python version to test against, e.g. '3.11'. May be
+            repeated to test against multiple versions. Overrides
+            any tool.whl2conda.test-python setting. If not specified,
+            the solver chooses the version.
+            """),
+    )
+    test_opts.add_argument(
+        "-p",
+        "--prefix",
+        metavar="<env-path>",
+        type=Path,
+        help=dedent("""
+            Path of test environment to create, instead of a
+            location in a temporary work directory. Only allowed
+            with a single python version. The environment is still
+            removed after testing unless --keep-test-env is given.
+            """),
+    )
+    test_opts.add_argument(
+        "--keep-test-env",
+        action="store_true",
+        help="Do not delete the test environment (for debugging).",
+    )
+    test_opts.add_argument(
+        "--mamba",
+        dest="use_mamba",
+        action="store_true",
+        help="Use mamba instead of conda to create and run test environments.",
+    )
+
+    common_opts = parser.add_argument_group("common options")
+    common_opts.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Display the tests that would be run without running them.",
+    )
+    common_opts.add_argument(
+        "-q",
+        "--quiet",
+        action="count",
+        default=0,
+        help="Less verbose output. May be repeated.",
+    )
+    common_opts.add_argument(
+        "--debug",
+        action="store_true",
+        help="Show debug output.",
+    )
+    add_markdown_help(parser)
+    return parser
+
+
+def test_main(
+    args: Sequence[str] | None = None,
+    prog: str | None = None,
+) -> None:
+    """Main procedure for `whl2conda test` command"""
+    parser = _create_argparser(prog)
+    parsed = parser.parse_args(args)
+    testargs = TestArgs(**vars(parsed))
+
+    verbosity = (1 if testargs.debug else 0) - testargs.quiet
+    if verbosity < -1:
+        level = logging.ERROR
+    elif verbosity < 0:
+        level = logging.WARNING
+    elif verbosity == 0:
+        level = logging.INFO
+    else:
+        level = logging.DEBUG
+    logging.getLogger().setLevel(level)
+    logging.basicConfig(level=level, format="%(message)s")
+
+    if testargs.prefix and len(testargs.python) > 1:
+        parser.error("-p/--prefix is not allowed with multiple --python versions")
+
+    work_dir = Path(tempfile.mkdtemp(prefix="whl2conda-test-"))
+    try:
+        spec, source_root, project_python = _resolve_test_spec(testargs, work_dir)
+        if not spec:
+            parser.error(
+                f"No tests found for {testargs.project_dir}: expected a"
+                " --test-file, a [tool.whl2conda.tests] pyproject section,"
+                " or a recipe with a test section"
+            )
+
+        python_versions: Sequence[str] = testargs.python or project_python or [""]
+
+        if testargs.dry_run:
+            _show_spec(spec, python_versions)
+            return
+
+        for python_version in python_versions:
+            if python_version:
+                logger.info("Testing with python %s", python_version)
+            env_suffix = f"-{python_version}" if python_version else ""
+            env_prefix = testargs.prefix or work_dir / f"test-env{env_suffix}"
+            run_package_tests(
+                testargs.package_file,
+                spec,
+                env_prefix=env_prefix,
+                work_dir=work_dir / f"test_tmp{env_suffix}",
+                source_root=source_root,
+                channels=testargs.channels,
+                keep_env=testargs.keep_test_env,
+                use_mamba=testargs.use_mamba,
+                python_version=python_version,
+            )
+        logger.info("All package tests passed")
+    except RecipeError as ex:
+        parser.error(str(ex))
+    except PackageTestError as ex:
+        print(f"ERROR: {ex}", file=sys.stderr)
+        sys.exit(1)
+    finally:
+        shutil.rmtree(work_dir, ignore_errors=True)
+
+
+def _resolve_test_spec(
+    testargs: TestArgs,
+    work_dir: Path,
+) -> tuple[PackageTestSpec, Path, Sequence[str]]:
+    """Resolve the test spec, source root, and project python versions.
+
+    Sources, in order of precedence: the --test-file option, the
+    pyproject.toml [tool.whl2conda.tests] section, and the test section
+    of a rendered conda recipe in the project directory.
+    """
+    if testargs.test_file:
+        spec = PackageTestSpec.from_file(testargs.test_file)
+        return spec, testargs.test_file.parent.absolute(), ()
+
+    project_dir = testargs.project_dir
+    pyproj = PyProjInfo()
+    if project_dir.joinpath("pyproject.toml").is_file():
+        pyproj = read_pyproject(project_dir)
+    if pyproj.tests:
+        spec = PackageTestSpec.from_v1_tests(pyproj.tests)
+        return spec, project_dir.absolute(), pyproj.test_python
+
+    if not any(
+        project_dir.joinpath(name).is_file()
+        for name in ("meta.yaml", "recipe.yaml")
+    ):
+        return PackageTestSpec(), project_dir.absolute(), ()
+
+    rendered = render_recipe(
+        project_dir, work_dir=work_dir, use_mamba=testargs.use_mamba
+    )
+    spec = _spec_from_recipe(rendered)
+    return spec, recipe_source_root(rendered, work_dir), pyproj.test_python
+
+
+def _spec_from_recipe(rendered: RenderedRecipe) -> PackageTestSpec:
+    """Extract the test spec from a rendered recipe."""
+    if tests := rendered.raw.get("tests"):
+        return PackageTestSpec.from_v1_tests(tests)
+    return PackageTestSpec.from_meta_yaml(rendered.raw.get("test") or {})
+
+
+def _show_spec(spec: PackageTestSpec, python_versions: Sequence[str]) -> None:
+    """Display the resolved test spec for --dry-run."""
+    versions = ", ".join(v for v in python_versions if v) or "<default>"
+    print(f"python versions: {versions}")
+    if spec.requires:
+        print("requires:")
+        for requirement in spec.requires:
+            print(f"  {requirement}")
+    if spec.source_files:
+        print("source files:")
+        for pattern in spec.source_files:
+            print(f"  {pattern}")
+    if spec.imports:
+        print("imports:")
+        for import_name in spec.imports:
+            print(f"  {import_name}")
+    if spec.pip_check:
+        print("pip check")
+    if spec.commands:
+        print("commands:")
+        for command in spec.commands:
+            print(f"  {command}")

--- a/src/whl2conda/cli/testenv.py
+++ b/src/whl2conda/cli/testenv.py
@@ -37,6 +37,7 @@ from typing import Any
 import yaml
 
 # this project
+from ..impl.recipe import RenderedRecipe
 from .install import install_main
 
 __all__ = [
@@ -136,6 +137,17 @@ class PackageTestSpec:
         )
 
     @classmethod
+    def from_rendered_recipe(cls, rendered: RenderedRecipe) -> PackageTestSpec:
+        """Create spec from the test section of a rendered conda recipe.
+
+        Reads the `tests` list of a v1 recipe, or else the `test`
+        section of a classic recipe.
+        """
+        if tests := rendered.raw.get("tests"):
+            return cls.from_v1_tests(tests)
+        return cls.from_meta_yaml(rendered.raw.get("test") or {})
+
+    @classmethod
     def from_file(cls, path: Path) -> PackageTestSpec:
         """Load spec from a YAML file containing a v1 recipe `tests` list.
 
@@ -159,6 +171,25 @@ class PackageTestSpec:
                 f"Test file {path} does not contain a v1 recipe `tests` list"
             )
         return cls.from_v1_tests(data)
+
+    def describe(self) -> str:
+        """Multi-line human-readable description of the tests."""
+        lines: list[str] = []
+        if self.requires:
+            lines.append("requires:")
+            lines.extend(f"  {requirement}" for requirement in self.requires)
+        if self.source_files:
+            lines.append("source files:")
+            lines.extend(f"  {pattern}" for pattern in self.source_files)
+        if self.imports:
+            lines.append("imports:")
+            lines.extend(f"  {import_name}" for import_name in self.imports)
+        if self.pip_check:
+            lines.append("pip check")
+        if self.commands:
+            lines.append("commands:")
+            lines.extend(f"  {command}" for command in self.commands)
+        return "\n".join(lines)
 
 
 def run_package_tests(

--- a/src/whl2conda/impl/recipe.py
+++ b/src/whl2conda/impl/recipe.py
@@ -37,6 +37,7 @@ __all__ = [
     "RecipeRenderError",
     "RenderedRecipe",
     "find_recipe_file",
+    "recipe_source_root",
     "render_recipe",
     "rewrite_build_script",
 ]
@@ -214,6 +215,29 @@ _PIP_BUILD_RE = re.compile(
     r"pip\s+(?P<cmd>install|wheel)\s+\.(?=\s|$)"
     r"(?P<post>.*)"
 )
+
+
+def recipe_source_root(rendered: RenderedRecipe, work_dir: Path) -> Path:
+    """Directory containing the project source for a rendered recipe.
+
+    This is the source copy in conda-build's work directory under
+    `work_dir` when it exists, otherwise the recipe's local `path:`
+    source when it has one, and otherwise the current directory.
+    """
+    for work_src in sorted(work_dir.glob("croot/*/work")):
+        # conda-build only populates the work dir when the recipe
+        # needs the source at render time
+        if any(work_src.iterdir()):
+            return work_src
+    sources = rendered.raw.get("source") or ()
+    if isinstance(sources, dict):
+        sources = (sources,)
+    for source in sources:
+        if isinstance(source, dict) and (path := source.get("path")):
+            source_root = (rendered.recipe_dir / str(path)).resolve()
+            if source_root.is_dir():
+                return source_root
+    return Path.cwd()
 
 
 def rewrite_build_script(recipe: RenderedRecipe, dist_dir: Path) -> list[str]:

--- a/test-projects/recipe/pyproject.toml
+++ b/test-projects/recipe/pyproject.toml
@@ -11,3 +11,11 @@ requires-python = ">=3.9"
 
 [tool.hatch.build.targets.wheel]
 packages = ["hello"]
+
+[[tool.whl2conda.tests]]
+python = { imports = ["hello"], pip_check = false }
+
+[[tool.whl2conda.tests]]
+script = ["pytest test"]
+requirements = { run = ["pytest"] }
+files = { source = ["test"] }

--- a/test/cli/test_main.py
+++ b/test/cli/test_main.py
@@ -41,7 +41,7 @@ def test_help(
     assert "usage: whl2conda2" in out
     assert "--markdown-help" not in out
 
-    subcmds = ["build", "convert", "config", "diff", "install"]
+    subcmds = ["build", "convert", "config", "diff", "install", "test"]
     for subcmd in subcmds:
         assert re.search(rf"^\s+{subcmd}\s+\w+", out, flags=re.MULTILINE)
 

--- a/test/cli/test_test.py
+++ b/test/cli/test_test.py
@@ -72,9 +72,7 @@ class FakeTest:
                 raw=fake.rendered_raw,
             )
 
-        monkeypatch.setattr(
-            "whl2conda.cli.test.run_package_tests", fake_run_tests
-        )
+        monkeypatch.setattr("whl2conda.cli.test.run_package_tests", fake_run_tests)
         monkeypatch.setattr("whl2conda.cli.test.render_recipe", fake_render)
 
         self.package = tmp_path / "simple-1.0-py_0.conda"
@@ -84,9 +82,7 @@ class FakeTest:
 
 
 @pytest.fixture
-def fake_test(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> FakeTest:
+def fake_test(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> FakeTest:
     return FakeTest(monkeypatch, tmp_path)
 
 

--- a/test/cli/test_test.py
+++ b/test/cli/test_test.py
@@ -25,7 +25,7 @@ import pytest
 
 from whl2conda.cli import main
 from whl2conda.cli.testenv import PackageTestError
-from whl2conda.impl.recipe import RecipeFormat, RenderedRecipe
+from whl2conda.impl.recipe import RecipeError, RecipeFormat, RenderedRecipe
 
 PYPROJECT_WITH_TESTS = dedent("""
     [project]
@@ -47,6 +47,7 @@ class FakeTest:
         self.tmp_path = tmp_path
         self.test_calls: list[dict[str, Any]] = []
         self.fail = False
+        self.render_fail = False
         self.rendered_raw: dict[str, Any] = {}
         self.render_calls: list[Path] = []
 
@@ -59,6 +60,8 @@ class FakeTest:
 
         def fake_render(recipe_dir: Path, **_kwargs) -> RenderedRecipe:
             fake.render_calls.append(recipe_dir)
+            if fake.render_fail:
+                raise RecipeError("render boom")
             fmt = (
                 RecipeFormat.V1
                 if (recipe_dir / "recipe.yaml").is_file()
@@ -237,3 +240,28 @@ def test_test_errors_and_modes(
         main(["test", str(fake_test.package), str(fake_test.project)])
     assert exc_info.value.code == 1
     assert "test failed" in capsys.readouterr().err
+
+    # recipe errors are reported as command line errors
+    fake_test.fail = False
+    fake_test.render_fail = True
+    (fake_test.project / "pyproject.toml").unlink()
+    (fake_test.project / "meta.yaml").write_text("unrendered")
+    with pytest.raises(SystemExit):
+        main(["test", str(fake_test.package), str(fake_test.project)])
+    assert "render boom" in capsys.readouterr().err
+
+
+def test_test_verbosity(fake_test: FakeTest) -> None:
+    """Verbosity options map to log levels"""
+    import logging
+
+    (fake_test.project / "pyproject.toml").write_text(PYPROJECT_WITH_TESTS)
+    base = ["test", str(fake_test.package), str(fake_test.project), "--dry-run"]
+    for flags, level in [
+        ([], logging.INFO),
+        (["--debug"], logging.DEBUG),
+        (["-q"], logging.WARNING),
+        (["-qq"], logging.ERROR),
+    ]:
+        main(base + flags)
+        assert logging.getLogger().getEffectiveLevel() == level

--- a/test/cli/test_test.py
+++ b/test/cli/test_test.py
@@ -1,0 +1,243 @@
+#  Copyright 2026 Christopher Barber
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Unit tests for `whl2conda test` subcommand
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+from typing import Any
+
+import pytest
+
+from whl2conda.cli import main
+from whl2conda.cli.testenv import PackageTestError
+from whl2conda.impl.recipe import RecipeFormat, RenderedRecipe
+
+PYPROJECT_WITH_TESTS = dedent("""
+    [project]
+    name = "simple"
+
+    [[tool.whl2conda.tests]]
+    python = { imports = ["simple"], pip_check = false }
+
+    [[tool.whl2conda.tests]]
+    script = ["pytest test"]
+    requirements = { run = ["pytest"] }
+    """)
+
+
+class FakeTest:
+    """Fakes the external actions of the test pipeline."""
+
+    def __init__(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        self.tmp_path = tmp_path
+        self.test_calls: list[dict[str, Any]] = []
+        self.fail = False
+        self.rendered_raw: dict[str, Any] = {}
+        self.render_calls: list[Path] = []
+
+        fake = self
+
+        def fake_run_tests(pkg: Path, spec, **kwargs) -> None:
+            fake.test_calls.append({"pkg": pkg, "spec": spec, **kwargs})
+            if fake.fail:
+                raise PackageTestError("test failed")
+
+        def fake_render(recipe_dir: Path, **_kwargs) -> RenderedRecipe:
+            fake.render_calls.append(recipe_dir)
+            fmt = (
+                RecipeFormat.V1
+                if (recipe_dir / "recipe.yaml").is_file()
+                else RecipeFormat.META_YAML
+            )
+            return RenderedRecipe(
+                format=fmt,
+                recipe_dir=recipe_dir,
+                name="simple",
+                version="1.0",
+                raw=fake.rendered_raw,
+            )
+
+        monkeypatch.setattr(
+            "whl2conda.cli.test.run_package_tests", fake_run_tests
+        )
+        monkeypatch.setattr("whl2conda.cli.test.render_recipe", fake_render)
+
+        self.package = tmp_path / "simple-1.0-py_0.conda"
+        self.package.write_bytes(b"")
+        self.project = tmp_path / "project"
+        self.project.mkdir()
+
+
+@pytest.fixture
+def fake_test(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> FakeTest:
+    return FakeTest(monkeypatch, tmp_path)
+
+
+def test_test_pyproject(fake_test: FakeTest) -> None:
+    """Tests from pyproject [tool.whl2conda.tests] section"""
+    (fake_test.project / "pyproject.toml").write_text(PYPROJECT_WITH_TESTS)
+
+    main([
+        "test",
+        str(fake_test.package),
+        str(fake_test.project),
+        "-c",
+        "my-channel",
+        "--keep-test-env",
+        "--mamba",
+    ])
+    assert len(fake_test.test_calls) == 1
+    call = fake_test.test_calls[0]
+    assert call["pkg"] == fake_test.package
+    assert call["spec"].imports == ("simple",)
+    assert call["spec"].commands == ("pytest test",)
+    assert call["channels"] == ["my-channel"]
+    assert call["keep_env"] is True
+    assert call["use_mamba"] is True
+    assert call["python_version"] == ""
+    assert call["source_root"] == fake_test.project
+    # recipe rendering never invoked
+    assert not fake_test.render_calls
+
+
+def test_test_python_matrix(fake_test: FakeTest) -> None:
+    """One test environment per python version"""
+    (fake_test.project / "pyproject.toml").write_text(
+        PYPROJECT_WITH_TESTS + '\n[tool.whl2conda]\ntest-python = ["3.10", "3.14"]\n'
+    )
+
+    # versions from pyproject
+    main(["test", str(fake_test.package), str(fake_test.project)])
+    versions = [call["python_version"] for call in fake_test.test_calls]
+    assert versions == ["3.10", "3.14"]
+    prefixes = {str(call["env_prefix"]) for call in fake_test.test_calls}
+    assert len(prefixes) == 2
+
+    # --python overrides pyproject
+    fake_test.test_calls.clear()
+    main([
+        "test",
+        str(fake_test.package),
+        str(fake_test.project),
+        "--python",
+        "3.12",
+    ])
+    versions = [call["python_version"] for call in fake_test.test_calls]
+    assert versions == ["3.12"]
+
+
+def test_test_from_recipe(fake_test: FakeTest) -> None:
+    """Tests from a rendered recipe test section"""
+    recipe_dir = fake_test.project
+    (recipe_dir / "meta.yaml").write_text("unrendered")
+    fake_test.rendered_raw = {"test": {"imports": ["simple"]}}
+
+    main(["test", str(fake_test.package), str(recipe_dir)])
+    assert fake_test.render_calls == [recipe_dir]
+    assert fake_test.test_calls[0]["spec"].imports == ("simple",)
+
+    # v1 recipe tests list
+    (recipe_dir / "meta.yaml").unlink()
+    (recipe_dir / "recipe.yaml").write_text("unrendered")
+    fake_test.rendered_raw = {"tests": [{"python": {"imports": ["simple"]}}]}
+    fake_test.test_calls.clear()
+    main(["test", str(fake_test.package), str(recipe_dir)])
+    spec = fake_test.test_calls[0]["spec"]
+    assert spec.imports == ("simple",)
+    assert spec.pip_check
+
+
+def test_test_file_option(fake_test: FakeTest) -> None:
+    """--test-file overrides project test specification"""
+    (fake_test.project / "pyproject.toml").write_text(PYPROJECT_WITH_TESTS)
+    test_file = fake_test.tmp_path / "mytests.yaml"
+    test_file.write_text("- python:\n    imports: [other]\n")
+
+    main([
+        "test",
+        str(fake_test.package),
+        str(fake_test.project),
+        "--test-file",
+        str(test_file),
+    ])
+    call = fake_test.test_calls[0]
+    assert call["spec"].imports == ("other",)
+    assert call["source_root"] == fake_test.tmp_path
+
+
+def test_test_errors_and_modes(
+    fake_test: FakeTest,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """Error handling, --prefix, --dry-run and exit status"""
+    # no tests found
+    with pytest.raises(SystemExit):
+        main(["test", str(fake_test.package), str(fake_test.project)])
+    assert "No tests found" in capsys.readouterr().err
+
+    (fake_test.project / "pyproject.toml").write_text(PYPROJECT_WITH_TESTS)
+
+    # --prefix with multiple python versions is rejected
+    with pytest.raises(SystemExit):
+        main([
+            "test",
+            str(fake_test.package),
+            str(fake_test.project),
+            "--python",
+            "3.10",
+            "--python",
+            "3.11",
+            "-p",
+            str(fake_test.tmp_path / "env"),
+        ])
+    assert "not allowed with multiple" in capsys.readouterr().err
+
+    # --prefix is passed through
+    main([
+        "test",
+        str(fake_test.package),
+        str(fake_test.project),
+        "-p",
+        str(fake_test.tmp_path / "env"),
+    ])
+    assert fake_test.test_calls[0]["env_prefix"] == fake_test.tmp_path / "env"
+
+    # --dry-run shows the spec without running tests
+    fake_test.test_calls.clear()
+    main([
+        "test",
+        str(fake_test.package),
+        str(fake_test.project),
+        "--dry-run",
+        "--python",
+        "3.12",
+    ])
+    assert not fake_test.test_calls
+    out = capsys.readouterr().out
+    assert "3.12" in out
+    assert "pytest test" in out
+    assert "simple" in out
+
+    # test failures exit with nonzero status
+    fake_test.fail = True
+    with pytest.raises(SystemExit) as exc_info:
+        main(["test", str(fake_test.package), str(fake_test.project)])
+    assert exc_info.value.code == 1
+    assert "test failed" in capsys.readouterr().err

--- a/zensical.toml
+++ b/zensical.toml
@@ -35,6 +35,7 @@ nav = [
       { "whl2conda convert" = "reference/cli/whl2conda-convert.md" },
       { "whl2conda diff" = "reference/cli/whl2conda-diff.md" },
       { "whl2conda install" = "reference/cli/whl2conda-install.md" },
+      { "whl2conda test" = "reference/cli/whl2conda-test.md" },
     ] },
     { "API (not stable!)" = [
       { "compare" = "reference/api/compare.md" },


### PR DESCRIPTION
Second PR implementing the design proposal in https://github.com/zuzukin/whl2conda/issues/190#issuecomment-4951872045 (stacked on #220). Closes #83, closes #190.

Adds the `whl2conda test` subcommand:

```
whl2conda test PACKAGE_FILE [PROJECT_DIR] [options]
```

- **Spec sources**, in order of precedence: `--test-file` YAML (v1 `tests` list, bare or as a `tests:` mapping excerpt) → `[[tool.whl2conda.tests]]` in pyproject.toml → the test section of a `meta.yaml`/`recipe.yaml` in the project directory (rendered through the same machinery as `whl2conda build`, so jinja and v1 recipes both work). A clear error if no tests are found.
- **Python matrix**: `--python` may be repeated (one fresh environment per version), defaulting to `tool.whl2conda.test-python`; `source_files` resolve from the pyproject/YAML directory or the recipe source root (shared `recipe_source_root()` helper extracted from the build command).
- **Environment control**: `-c/--channel`, `--keep-test-env`, `--mamba`, and `-p/--prefix` (single version only); `--dry-run` prints the resolved tests without running.
- Exit status reflects test success for scripts/CI.
- Documented in the "Installing and Testing" guide with a nav entry for the generated CLI reference page.
- Housekeeping: ruff pytest-style rules (`PT`) are now disabled for `src/**`, since `cli/test.py` is not a pytest module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)