### PR TITLE
Fix --resolve-extras against real pypi metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [26.8.0] - *in progress*
 
+### Bug fixes
+
+* `--resolve-extras` no longer fails to resolve extras of packages
+  whose pypi metadata does not populate `provides_extra` (which is
+  commonly null even when the extras exist); the extra's entries in
+  `Requires-Dist` are now authoritative. Found by a new external test
+  exercising the real pypi.org metadata API.
+
 ### Features
 
 * `whl2conda build` now supports v1 (`recipe.yaml`) recipes, as built

--- a/src/whl2conda/api/converter.py
+++ b/src/whl2conda/api/converter.py
@@ -1206,7 +1206,19 @@ class Wheel2CondaConverter:
             return None
 
         norm_extra = normalize_pypi_name(extra)
-        if norm_extra not in (
+        entries = []
+        for raw in requires_dist:
+            try:
+                entry = RequiresDistEntry.parse(raw)
+            except SyntaxError:
+                continue
+            if normalize_pypi_name(entry.extra_marker_name) == norm_extra:
+                entries.append(_strip_extra_marker(entry))
+
+        if not entries and norm_extra not in (
+            # NOTE: provides_extra is often null in pypi metadata even
+            # when the extra exists, so it is only consulted to accept
+            # a declared-but-empty extra
             normalize_pypi_name(provided)
             for provided in info.get("provides_extra") or ()
         ):
@@ -1217,15 +1229,6 @@ class Wheel2CondaConverter:
                 extra,
             )
             return None
-
-        entries = []
-        for raw in requires_dist:
-            try:
-                entry = RequiresDistEntry.parse(raw)
-            except SyntaxError:
-                continue
-            if normalize_pypi_name(entry.extra_marker_name) == norm_extra:
-                entries.append(_strip_extra_marker(entry))
         self._info(
             "Resolved '%s[%s]' using version %s metadata: %s",
             package,

--- a/test/api/test_external.py
+++ b/test/api/test_external.py
@@ -131,6 +131,41 @@ def test_pypi_orix(test_case: ConverterTestCaseFactory) -> None:
 
 
 @pytest.mark.external
+def test_resolve_extras_live(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    Test --resolve-extras against the real pypi.org JSON API.
+
+    Uses a pinned uvicorn version so that the extra's dependencies
+    are immutable. This exercises the fetch_pypi_metadata network
+    path, which is mocked in the unit tests.
+    """
+    import logging
+
+    from whl2conda.api.converter import RequiresDistEntry, Wheel2CondaConverter
+
+    converter = Wheel2CondaConverter(tmp_path / "fake.whl", tmp_path)
+    converter.logger = logging.getLogger(__name__)
+    converter.resolve_extras = True
+
+    result = converter._compute_conda_dependencies([
+        RequiresDistEntry.parse("uvicorn[standard] ==0.30.0")
+    ])
+
+    names = {dep.split()[0] for dep in result}
+    # the base package is kept and the extra's unconditional
+    # dependencies are added from the pinned version's metadata
+    assert "uvicorn" in names
+    assert "httptools" in names
+    assert "watchfiles" in names
+    # platform-conditional extra dependencies are skipped for noarch
+    assert "uvloop" not in names
+    assert "Dropping extras" not in caplog.text
+
+
+@pytest.mark.external
 def test_pypi_markupsafe_binary(test_case: ConverterTestCaseFactory) -> None:
     """
     Test converting markupsafe binary wheel (simple C extension).


### PR DESCRIPTION
Recommended for inclusion in 26.7.2, since it repairs a feature released in 26.7.1.

A new external test resolving `uvicorn[standard]` at a pinned version against the live pypi.org API (the network path unit tests mock) immediately exposed a real-world failure: PyPI's JSON metadata commonly reports `provides_extra` as **null** even when the extras exist (uvicorn included), and the resolver required the extra to be listed there — so `--resolve-extras` bailed with "does not provide extra" for most real packages. The unit-test fixtures had modeled `provides_extra` as always populated.

The fix makes the extra-marked `Requires-Dist` entries authoritative: `provides_extra` is now only consulted to accept a declared-but-empty extra, and the unknown-extra warning fires only when neither source knows the extra.

After merging, the `release/26.7.2` branch (#226) should be refreshed with a merge from main — say the word and Claude will handle it.

(The same change is already on the `code-cleanup` branch, which will reconcile via its next merge from main.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)