### PR TITLE
Support binary (non-noarch) recipes in whl2conda build (#216)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [next] - *in progress*
 
+### Features
+
+* `whl2conda build` now supports recipes for platform-specific binary
+  packages: when the recipe does not declare `noarch: python`, the
+  built wheel is converted with binary conversion enabled and the
+  package is written and installed into the target platform subdir.
+  The `--output`, `-t`/`--test`, and `--skip-existing` options remain
+  restricted to noarch recipes. (#216)
+* `whl2conda build` and `whl2conda test` now pass
+  `-m`/`--variant-config-files` through to the recipe renderer,
+  which is required by recipes using variant-dependent expressions
+  such as `stdlib('c')`; the unresolved `${{ PYTHON }}` template in
+  rendered v1 build scripts is now handled. (#216)
+
 ### Development
 
 * Code readability overhaul from an internal review: oriented and

--- a/doc/guide/building.md
+++ b/doc/guide/building.md
@@ -19,11 +19,26 @@ Instead of solving and creating build/host/test environments, whl2conda:
 Because there is no build environment, this is much faster than
 `conda build`, but it only works for recipes that:
 
-* build a pure python (`noarch: python`) package
-  (see [#216] for planned binary package support),
-* whose build script consists of a single `pip install .` or
+* have a build script consisting of a single `pip install .` or
   `pip wheel .` command (extra pip options are fine), and
 * produce a single output package.
+
+Both pure python (`noarch: python`) and platform-specific binary
+recipes are supported. For binary recipes, the wheel is built with
+your local toolchain via the project's build backend — not in the
+recipe's `build`/`host` conda environments — so this works for
+self-contained extension modules but not for recipes that require
+conda-provided compilers or libraries (see the
+[Binary Conversion](binary-conversion.md) guide for the conversion
+limitations), and the built wheel reflects your local toolchain
+settings (e.g. the macOS deployment target). Recipes that use
+variant-dependent expressions such as `${{ compiler('c') }}` or
+`${{ stdlib('c') }}` need a variant configuration file to render,
+which can be supplied with `-m`/`--variant-config-files`. Only the variant for the python version used in the
+build is produced, and the `--output`, `-t`/`--test`, and
+`--skip-existing` options remain restricted to noarch recipes, since
+a binary package's file name cannot be predicted before the wheel is
+built.
 
 ## Supported recipe formats
 
@@ -128,7 +143,6 @@ fresh conda environment created with `whl2conda install`:
   test environment, unlike rattler-build, which creates a separate
   environment per element.
 
-[#216]: https://github.com/zuzukin/whl2conda/issues/216
 [conda-build]: https://docs.conda.io/projects/conda-build/
 [rattler-build]: https://rattler.build/
 [py-rattler-build]: https://pypi.org/project/py-rattler-build/

--- a/src/whl2conda/cli/build.py
+++ b/src/whl2conda/cli/build.py
@@ -48,6 +48,7 @@ from .common import (
     add_markdown_help,
     dedent,
     existing_dir,
+    existing_path,
     get_conda_bld_path,
     maybe_existing_dir,
     setup_logging,
@@ -82,8 +83,10 @@ def predict_package_path(
     if not rendered.noarch_python:
         raise RecipeError(
             f"Cannot predict package path for recipe in {rendered.recipe_dir}:"
-            " it does not build a `noarch: python` package"
-            " (see https://github.com/zuzukin/whl2conda/issues/216)"
+            " it does not build a `noarch: python` package, whose file name"
+            " would depend on the python version and platform of the built"
+            " wheel. The --output, -t/--test and --skip-existing options"
+            " therefore only support noarch python recipes."
         )
     name = normalize_pypi_name(rendered.name)
     build_string = noarch_build_string(rendered.build_number)
@@ -114,6 +117,7 @@ class BuildArgs:
     skip_existing: bool
     test_only: bool
     use_mamba: bool
+    variant_config: list[Path]
 
 
 class _IgnoredOption(argparse.Action):
@@ -193,9 +197,9 @@ _IGNORED_OPTIONS: list[tuple[tuple[str, ...], int]] = [
     (("--no-remove-work-dir",), 0),
     # packages are always written with the default compression
     (("--zstd-compression-level",), 1),
-    # variant matrices do not arise for a single noarch python output;
-    # variant config file options are accepted for CLI compatibility
-    (("-m", "--variant-config-files"), 1),
+    # variant matrices do not arise for a single output package;
+    # inline variant options are accepted for CLI compatibility
+    # (variant config *files* are supported and passed to the renderer)
     (("--variants",), 1),
     (("-e", "--exclusive-config-files", "--exclusive-config-file"), 1),
     (("--append-file",), 1),
@@ -336,6 +340,20 @@ def _create_argparser(prog: str | None = None) -> argparse.ArgumentParser:
         help="Output package format: '1'/'tar.bz2' or '2'/'conda' (default)",
     )
     conda_opts.add_argument(
+        "-m",
+        "--variant-config-files",
+        dest="variant_config",
+        metavar="<file>",
+        action="append",
+        default=[],
+        type=existing_path,
+        help=dedent("""
+            Additional variant configuration file passed to the recipe
+            renderer. Needed by recipes using variant-dependent
+            expressions (e.g. compilers or stdlib). May be repeated.
+            """),
+    )
+    conda_opts.add_argument(
         "--croot",
         metavar="<dir>",
         type=maybe_existing_dir,
@@ -470,6 +488,7 @@ class CondaBuild:
                 self.recipe_path,
                 work_dir=self.work_dir,
                 use_mamba=self.args.use_mamba,
+                variant_config=self.args.variant_config,
             )
 
             if self.args.output:
@@ -539,19 +558,28 @@ class CondaBuild:
             ) from None
 
     def _build_package(self, wheel: Path, rendered: RenderedRecipe) -> Path:
-        out_dir = self.work_dir
-        if self.args.output_folder:
-            out_dir = self.args.output_folder / "noarch"
-        converter = Wheel2CondaConverter(wheel, out_dir)
+        converter = Wheel2CondaConverter(wheel, self.work_dir)
         if self.args.package_format:
             converter.out_format = self.args.package_format
         converter.extra_dependencies.extend(self.args.extra_deps)
         converter.python_version = self.args.python
         converter.build_number = rendered.build_number
         converter.overwrite = True
+        if not rendered.noarch_python:
+            # recipe builds a platform-specific package (#216)
+            converter.allow_impure = True
         pkg = converter.convert()
         if converter.conda_target is not None:
             self.subdir = converter.conda_target.subdir
+        if self.args.output_folder:
+            # place package in the target platform subdir, which is
+            # not known until the built wheel has been examined
+            dest_dir = self.args.output_folder / self.subdir
+            dest_dir.mkdir(parents=True, exist_ok=True)
+            dest = dest_dir / pkg.name
+            shutil.move(pkg, dest)
+            logger.info("Moved package to %s", dest)
+            pkg = dest
         return pkg
 
     def _run_package_tests(self, pkg: Path, rendered: RenderedRecipe) -> None:

--- a/src/whl2conda/cli/test.py
+++ b/src/whl2conda/cli/test.py
@@ -63,6 +63,7 @@ class TestArgs:
     quiet: int
     test_file: Path | None
     use_mamba: bool
+    variant_config: list[Path]
 
 
 def _create_argparser(prog: str | None = None) -> argparse.ArgumentParser:
@@ -145,6 +146,19 @@ def _create_argparser(prog: str | None = None) -> argparse.ArgumentParser:
             location in a temporary work directory. Only allowed
             with a single python version. The environment is still
             removed after testing unless --keep-test-env is given.
+            """),
+    )
+    test_opts.add_argument(
+        "-m",
+        "--variant-config-files",
+        dest="variant_config",
+        metavar="<file>",
+        action="append",
+        default=[],
+        type=existing_path,
+        help=dedent("""
+            Additional variant configuration file passed to the recipe
+            renderer when reading tests from a recipe. May be repeated.
             """),
     )
     test_opts.add_argument(
@@ -267,7 +281,10 @@ def _resolve_test_spec(
         return PackageTestSpec(), project_dir.absolute(), ()
 
     rendered = render_recipe(
-        project_dir, work_dir=work_dir, use_mamba=testargs.use_mamba
+        project_dir,
+        work_dir=work_dir,
+        use_mamba=testargs.use_mamba,
+        variant_config=testargs.variant_config,
     )
     spec = PackageTestSpec.from_rendered_recipe(rendered)
     return spec, recipe_source_root(rendered, work_dir), pyproj.test_python

--- a/src/whl2conda/impl/recipe.py
+++ b/src/whl2conda/impl/recipe.py
@@ -132,13 +132,18 @@ def render_recipe(
     if recipe_format is RecipeFormat.V1:
         from .render_v1 import render_v1_yaml  # noqa: PLC0415
 
-        raw = render_v1_yaml(recipe_file)
+        raw = render_v1_yaml(recipe_file, variant_config)
         return _normalize_v1(raw, recipe_dir)
 
     # local import so that recipe.py has no yaml dependency at import time
     from .render_meta import render_meta_yaml  # noqa: PLC0415
 
-    raw = render_meta_yaml(recipe_dir, work_dir=work_dir, use_mamba=use_mamba)
+    raw = render_meta_yaml(
+        recipe_dir,
+        work_dir=work_dir,
+        use_mamba=use_mamba,
+        variant_config=variant_config,
+    )
     return _normalize_meta_yaml(raw, recipe_dir)
 
 
@@ -159,20 +164,9 @@ def _normalize_meta_yaml(raw: Mapping[str, Any], recipe_dir: Path) -> RenderedRe
 
 
 def _normalize_v1(raw: Mapping[str, Any], recipe_dir: Path) -> RenderedRecipe:
-    """Normalize a rendered v1 recipe.yaml document.
-
-    Raises:
-        RecipeError: if the recipe does not build a `noarch: python`
-            package.
-    """
+    """Normalize a rendered v1 recipe.yaml document."""
     package = raw.get("package") or {}
     build = raw.get("build") or {}
-    if build.get("noarch") != "python":
-        raise RecipeError(
-            f"Cannot build from v1 recipe in {recipe_dir}: whl2conda build"
-            " only supports v1 recipes with `noarch: python`"
-            " (see https://github.com/zuzukin/whl2conda/issues/216)"
-        )
     return RenderedRecipe(
         format=RecipeFormat.V1,
         recipe_dir=recipe_dir,
@@ -180,7 +174,7 @@ def _normalize_v1(raw: Mapping[str, Any], recipe_dir: Path) -> RenderedRecipe:
         version=str(package.get("version") or ""),
         build_number=_build_number(build),
         build_script=_script_lines(build.get("script")),
-        noarch_python=True,
+        noarch_python=build.get("noarch") == "python",
         raw=raw,
     )
 
@@ -208,10 +202,16 @@ def _script_lines(script: Any) -> tuple[str, ...]:
 
 
 #: Matches a `pip install .` or `pip wheel .` line, possibly prefixed
-#: with a python interpreter invocation and followed by extra options.
+#: with a python interpreter invocation - including the unresolved
+#: `${{ PYTHON }}` template that rattler-build leaves in rendered v1
+#: scripts - and followed by extra options. The interpreter prefix is
+#: dropped by the rewrite.
 _PIP_BUILD_RE = re.compile(
     r"(?P<pre>.*?)"
-    r"(?:python\d?(?:\.\d+)?\s+-m\s+)?"
+    r"(?:"
+    r"python\d?(?:\.\d+)?\s+-m\s+"
+    r"|(?:\$?\{\{\s*PYTHON\s*\}\}|\$PYTHON)\s+(?:-m\s+)?"
+    r")?"
     r"pip\s+(?P<cmd>install|wheel)\s+\.(?=\s|$)"
     r"(?P<post>.*)"
 )

--- a/src/whl2conda/impl/render_meta.py
+++ b/src/whl2conda/impl/render_meta.py
@@ -28,6 +28,7 @@ import importlib.util
 import io
 import logging
 import subprocess
+from collections.abc import Sequence
 from pathlib import Path
 from textwrap import dedent
 from typing import Any
@@ -44,7 +45,7 @@ logger = logging.getLogger(__name__)
 
 _RENDER_SCRIPT = dedent("""
     import conda_build.api as api
-    config = api.Config(croot=r"{croot}")
+    config = api.Config(croot=r"{croot}", variant_config_files={variant_files!r})
     mds = api.render(r"{recipe_dir}", config=config, bypass_env_check=True)
     if len(mds) > 1:
         import sys
@@ -59,6 +60,7 @@ def render_meta_yaml(
     *,
     work_dir: Path,
     use_mamba: bool = False,
+    variant_config: Sequence[Path] = (),
 ) -> dict[str, Any]:
     """Render a classic meta.yaml recipe using conda-build.
 
@@ -68,6 +70,7 @@ def render_meta_yaml(
             scratch files are redirected into `<work_dir>/croot`
         use_mamba: use mamba instead of conda to run conda-build in
             the base environment (ignored for the in-process path)
+        variant_config: variant configuration files, if any
 
     Returns:
         The rendered recipe as a dictionary.
@@ -80,9 +83,11 @@ def render_meta_yaml(
     croot.mkdir(parents=True, exist_ok=True)
 
     if importlib.util.find_spec("conda_build") is not None:
-        _render_in_process(recipe_dir, croot, out_file)
+        _render_in_process(recipe_dir, croot, out_file, variant_config)
     else:
-        _render_in_base_env(recipe_dir, croot, out_file, use_mamba=use_mamba)
+        _render_in_base_env(
+            recipe_dir, croot, out_file, variant_config, use_mamba=use_mamba
+        )
 
     if not out_file.is_file():
         raise RecipeRenderError(
@@ -91,7 +96,12 @@ def render_meta_yaml(
     return yaml.safe_load(out_file.read_text("utf8"))
 
 
-def _render_in_process(recipe_dir: Path, croot: Path, out_file: Path) -> None:
+def _render_in_process(
+    recipe_dir: Path,
+    croot: Path,
+    out_file: Path,
+    variant_config: Sequence[Path],
+) -> None:
     """Render using conda-build imported into this process."""
     logger.debug("Rendering %s with in-process conda-build", recipe_dir)
     # conda-build is an optional runtime dependency, not installed here
@@ -102,7 +112,10 @@ def _render_in_process(recipe_dir: Path, croot: Path, out_file: Path) -> None:
     chatter = io.StringIO()
     try:
         with contextlib.redirect_stdout(chatter):
-            config = api.Config(croot=str(croot))
+            config = api.Config(
+                croot=str(croot),
+                variant_config_files=[str(f) for f in variant_config],
+            )
             mds = api.render(str(recipe_dir), config=config, bypass_env_check=True)
             if len(mds) > 1:
                 logger.warning("Recipe has multiple variants; using the first")
@@ -120,13 +133,17 @@ def _render_in_base_env(
     recipe_dir: Path,
     croot: Path,
     out_file: Path,
+    variant_config: Sequence[Path],
     *,
     use_mamba: bool = False,
 ) -> None:
     """Render by running conda-build in the conda base environment."""
     logger.debug("Rendering %s with conda-build from base env", recipe_dir)
     script = _RENDER_SCRIPT.format(
-        croot=croot, recipe_dir=recipe_dir, out_file=out_file
+        croot=croot,
+        recipe_dir=recipe_dir,
+        out_file=out_file,
+        variant_files=[str(f) for f in variant_config],
     )
     conda = "mamba" if use_mamba else "conda"
     cmd = [conda, "run", "-n", "base", "python", "-c", script]

--- a/src/whl2conda/impl/render_v1.py
+++ b/src/whl2conda/impl/render_v1.py
@@ -28,6 +28,7 @@ import json
 import logging
 import shutil
 import subprocess
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
@@ -39,11 +40,16 @@ __all__ = ["render_v1_yaml"]
 logger = logging.getLogger(__name__)
 
 
-def render_v1_yaml(recipe_file: Path) -> dict[str, Any]:
+def render_v1_yaml(
+    recipe_file: Path,
+    variant_config: Sequence[Path] = (),
+) -> dict[str, Any]:
     """Render a v1 recipe.yaml recipe using rattler-build.
 
     Args:
         recipe_file: the recipe.yaml file
+        variant_config: variant configuration files, needed by recipes
+            using variant-dependent expressions like `stdlib('c')`
 
     Returns:
         The rendered recipe as a dictionary.
@@ -53,13 +59,16 @@ def render_v1_yaml(recipe_file: Path) -> dict[str, Any]:
             recipe renders to more than one output.
         RecipeRenderError: if rendering fails.
     """
-    raw = _render_in_process(recipe_file)
+    raw = _render_in_process(recipe_file, variant_config)
     if raw is None:
-        raw = _render_with_cli(recipe_file)
+        raw = _render_with_cli(recipe_file, variant_config)
     return raw
 
 
-def _render_in_process(recipe_file: Path) -> dict[str, Any] | None:
+def _render_in_process(
+    recipe_file: Path,
+    variant_config: Sequence[Path],
+) -> dict[str, Any] | None:
     """Render using py-rattler-build, or return None if unavailable."""
     if importlib.util.find_spec("rattler_build") is None:
         return None
@@ -81,7 +90,12 @@ def _render_in_process(recipe_file: Path) -> dict[str, Any] | None:
     except TypeError:
         raise _multiple_outputs_error(recipe_file) from None
     try:
-        variants = recipe.render()
+        config = None
+        if variant_config:
+            config = rattler_build.VariantConfig.from_files([
+                str(f) for f in variant_config
+            ])
+        variants = recipe.render(variant_config=config)
     except Exception as ex:
         raise RecipeRenderError(
             f"rattler-build failed to render {recipe_file}: {ex}"
@@ -91,7 +105,10 @@ def _render_in_process(recipe_file: Path) -> dict[str, Any] | None:
     return variants[0].recipe.to_dict()
 
 
-def _render_with_cli(recipe_file: Path) -> dict[str, Any]:
+def _render_with_cli(
+    recipe_file: Path,
+    variant_config: Sequence[Path],
+) -> dict[str, Any]:
     """Render by running the rattler-build executable."""
     exe = shutil.which("rattler-build")
     if exe is None:
@@ -103,6 +120,8 @@ def _render_with_cli(recipe_file: Path) -> dict[str, Any]:
     logger.debug("Rendering %s with %s", recipe_file, exe)
 
     cmd = [exe, "build", "--render-only", "--recipe", str(recipe_file)]
+    for config_file in variant_config:
+        cmd.extend(["-m", str(config_file)])
     result = subprocess.run(cmd, capture_output=True, encoding="utf8", check=False)
     if result.returncode != 0:
         stderr_tail = "\n".join(result.stderr.splitlines()[-15:])

--- a/test/cli/test_build.py
+++ b/test/cli/test_build.py
@@ -58,6 +58,8 @@ class FakeBuild:
         self.install_calls: list[tuple[list[Path], str, dict[str, Any]]] = []
         self.rendered_raw: dict[str, Any] = dict(RENDERED_RAW)
         self.rendered_format = RecipeFormat.META_YAML
+        self.binary_wheel = False
+        """Fake conversion produces a platform-specific package"""
         self.render_kwargs: dict[str, Any] = {}
 
         fake = self
@@ -90,6 +92,7 @@ class FakeBuild:
 
         def fake_convert(converter: Wheel2CondaConverter) -> Path:
             fake.converter = converter
+            binary = fake.binary_wheel
             converter.conda_target = CondaTargetInfo.from_wheel_metadata(
                 MetadataFromWheel(
                     md={},
@@ -99,13 +102,14 @@ class FakeBuild:
                     license=None,
                     dependencies=[],
                     wheel_info_dir=fake.tmp_path,
-                    is_pure_python=True,
-                    python_tag="py3",
-                    abi_tag="none",
-                    platform_tag="any",
+                    is_pure_python=not binary,
+                    python_tag="cp312" if binary else "py3",
+                    abi_tag="cp312" if binary else "none",
+                    platform_tag="manylinux2014_x86_64" if binary else "any",
                 )
             )
-            pkg = Path(converter.out_dir) / "simple-1.2.3-py_0.conda"
+            build = converter.conda_target.build_string
+            pkg = Path(converter.out_dir) / f"simple-1.2.3-{build}.conda"
             pkg.parent.mkdir(parents=True, exist_ok=True)
             pkg.write_bytes(b"")
             return pkg
@@ -166,6 +170,7 @@ def test_build_options(
     """Converter and test options are wired through"""
     fake, recipe_dir = fake_build
     out_folder = tmp_path / "out"
+    (tmp_path / "variants.yaml").write_text("c_stdlib: [sysroot]\n")
     main([
         "build",
         str(recipe_dir),
@@ -183,12 +188,15 @@ def test_build_options(
         "my-channel",
         "--keep-test-env",
         "--mamba",
+        "-m",
+        str(tmp_path / "variants.yaml"),
     ])
 
     converter = fake.converter
     assert converter is not None
     assert converter.out_format is CondaPackageFormat.V1
-    assert Path(converter.out_dir) == out_folder / "noarch"
+    # package is moved into the output folder's platform subdir
+    assert (out_folder / "noarch" / "simple-1.2.3-py_0.conda").is_file()
     assert converter.extra_dependencies == ["extra-one >=1", "extra-two"]
     assert converter.python_version == ">=3.10"
 
@@ -197,6 +205,7 @@ def test_build_options(
     assert test_call["keep_env"] is True
     assert test_call["use_mamba"] is True
     assert fake.render_kwargs["use_mamba"] is True
+    assert fake.render_kwargs["variant_config"] == [tmp_path / "variants.yaml"]
 
     # package written to --output-folder: no conda-bld install
     assert not fake.install_calls
@@ -289,6 +298,7 @@ def test_build_wheel_step(
         "package_format": None,
         "python": "",
         "quiet": 0,
+        "variant_config": [],
     })
     builder = CondaBuild(BuildArgs(**parser_defaults))
     builder.build_script = [f"pip wheel . -w {dist_dir}"]
@@ -420,8 +430,7 @@ def test_build_output_mode(
     # prediction matches where the actual build puts the package
     main(["build", str(recipe_dir), "--no-test", "--output-folder", str(out_folder)])
     assert fake.converter is not None
-    actual = Path(fake.converter.out_dir) / "simple-1.2.3-py_0.conda"
-    assert actual == out_folder / "noarch" / "simple-1.2.3-py_0.conda"
+    actual = out_folder / "noarch" / "simple-1.2.3-py_0.conda"
     assert actual.is_file()
 
 
@@ -719,3 +728,49 @@ def test_build_e2e_with_tests(
         "-c",
         "conda-forge",
     ])
+
+
+BINARY_RENDERED_RAW: dict[str, Any] = {
+    "package": {"name": "simple", "version": "1.2.3"},
+    "build": {"number": 0, "script": "pip install ."},
+    "test": {"imports": ["simple"]},
+}
+
+
+def test_build_binary_recipe(
+    fake_build: tuple[FakeBuild, Path],
+    tmp_path: Path,
+) -> None:
+    """Non-noarch recipes convert as binary packages (#216)"""
+    fake, recipe_dir = fake_build
+    fake.rendered_raw = dict(BINARY_RENDERED_RAW)
+    fake.binary_wheel = True
+
+    # conda-bld install goes into the target platform subdir
+    main(["build", str(recipe_dir), "--no-test"])
+    assert fake.converter is not None
+    assert fake.converter.allow_impure is True
+    files, subdir, _kwargs = fake.install_calls[0]
+    assert subdir == "linux-64"
+    assert files[0].name == "simple-1.2.3-py312_0.conda"
+
+    # --output-folder places the package in the platform subdir
+    out_folder = tmp_path / "out"
+    main(["build", str(recipe_dir), "--no-test", "--output-folder", str(out_folder)])
+    assert (out_folder / "linux-64" / "simple-1.2.3-py312_0.conda").is_file()
+
+    # render-only modes remain restricted to noarch recipes
+    for mode in (["--output"], ["-t"], ["--skip-existing"]):
+        with pytest.raises(SystemExit):
+            main(["build", str(recipe_dir), *mode])
+
+    # v1 binary recipes are likewise accepted
+    fake.rendered_format = RecipeFormat.V1
+    fake.rendered_raw = {
+        "package": {"name": "simple", "version": "1.2.3"},
+        "build": {"number": 0, "script": "pip install ."},
+        "tests": [],
+    }
+    fake.install_calls.clear()
+    main(["build", str(recipe_dir), "--no-test"])
+    assert fake.install_calls[0][1] == "linux-64"

--- a/test/cli/test_test.py
+++ b/test/cli/test_test.py
@@ -50,6 +50,7 @@ class FakeTest:
         self.render_fail = False
         self.rendered_raw: dict[str, Any] = {}
         self.render_calls: list[Path] = []
+        self.render_kwargs: dict[str, Any] = {}
 
         fake = self
 
@@ -58,8 +59,9 @@ class FakeTest:
             if fake.fail:
                 raise PackageTestError("test failed")
 
-        def fake_render(recipe_dir: Path, **_kwargs) -> RenderedRecipe:
+        def fake_render(recipe_dir: Path, **kwargs) -> RenderedRecipe:
             fake.render_calls.append(recipe_dir)
+            fake.render_kwargs = kwargs
             if fake.render_fail:
                 raise RecipeError("render boom")
             fmt = (
@@ -148,8 +150,11 @@ def test_test_from_recipe(fake_test: FakeTest) -> None:
     (recipe_dir / "meta.yaml").write_text("unrendered")
     fake_test.rendered_raw = {"test": {"imports": ["simple"]}}
 
-    main(["test", str(fake_test.package), str(recipe_dir)])
+    variants = fake_test.tmp_path / "variants.yaml"
+    variants.write_text("c_stdlib: [sysroot]\n")
+    main(["test", str(fake_test.package), str(recipe_dir), "-m", str(variants)])
     assert fake_test.render_calls == [recipe_dir]
+    assert fake_test.render_kwargs["variant_config"] == [variants]
     assert fake_test.test_calls[0]["spec"].imports == ("simple",)
 
     # v1 recipe tests list

--- a/test/cli/test_testenv.py
+++ b/test/cli/test_testenv.py
@@ -297,6 +297,7 @@ def test_build_test_adapter(
             "skip_existing": False,
             "test_only": False,
             "use_mamba": True,
+            "variant_config": [],
         }
         values.update(overrides)
         return BuildArgs(**values)

--- a/test/impl/test_recipe.py
+++ b/test/impl/test_recipe.py
@@ -430,6 +430,12 @@ def test_render_v1_yaml_in_process(
     assert render_v1_yaml(recipe_file) == RENDERED_V1
     assert fake.Stage0Recipe.paths == [str(recipe_file)]
 
+    # variant config files are loaded and passed to the renderer
+    variants_file = tmp_path / "variants.yaml"
+    variants_file.write_text("c_stdlib: [sysroot]\n")
+    assert render_v1_yaml(recipe_file, [variants_file]) == RENDERED_V1
+    assert fake.VariantConfig.files == [str(variants_file)]
+
     monkeypatch.setitem(sys.modules, "rattler_build", _fake_rattler_module(multi=True))
     with pytest.raises(RecipeError, match="multiple outputs"):
         render_v1_yaml(recipe_file)
@@ -502,6 +508,12 @@ def test_render_v1_yaml_cli(
     assert cmd[0] == "/bin/rattler-build"
     assert "--render-only" in cmd
     assert str(recipe_file) in cmd
+
+    # variant config files are passed with -m
+    variants_file = tmp_path / "variants.yaml"
+    variants_file.write_text("c_stdlib: [sysroot]\n")
+    render_v1_yaml(recipe_file, [variants_file])
+    assert commands[-1][commands[-1].index("-m") + 1] == str(variants_file)
 
     # multiple outputs are rejected
     stdout = json.dumps([{"recipe": RENDERED_V1}, {"recipe": RENDERED_V1}])

--- a/test/impl/test_recipe.py
+++ b/test/impl/test_recipe.py
@@ -133,7 +133,7 @@ def test_render_recipe_v1(
     rendered_raw = dict(RENDERED_V1)
     monkeypatch.setattr(
         "whl2conda.impl.render_v1.render_v1_yaml",
-        lambda _recipe_file: dict(rendered_raw),
+        lambda _recipe_file, *_args: dict(rendered_raw),
     )
 
     rendered = render_recipe(recipe_dir, work_dir=tmp_path / "work")
@@ -160,10 +160,10 @@ def test_render_recipe_v1(
     rendered = render_recipe(recipe_dir, work_dir=tmp_path / "work")
     assert rendered.build_script == ()
 
-    # non-noarch v1 recipes are rejected
+    # non-noarch v1 recipes are accepted for binary conversion (#216)
     rendered_raw["build"] = {"script": "pip install ."}
-    with pytest.raises(RecipeError, match="noarch: python"):
-        render_recipe(recipe_dir, work_dir=tmp_path / "work")
+    rendered = render_recipe(recipe_dir, work_dir=tmp_path / "work")
+    assert not rendered.noarch_python
 
 
 def make_rendered(script: str | list[str]) -> RenderedRecipe:
@@ -193,10 +193,14 @@ def test_rewrite_build_script(tmp_path: Path) -> None:
         ("python -m pip install .", f"pip wheel . -w {dist}"),
         ("python3 -m pip install .", f"pip wheel . -w {dist}"),
         ("python3.12 -m pip install .", f"pip wheel . -w {dist}"),
+        # interpreter templates are dropped, since they are not
+        # resolved in rendered v1 scripts
+        ("{{ PYTHON }} pip install . -vv", f"pip wheel . -w {dist} -vv"),
         (
-            '{{ PYTHON }} pip install . -vv',
-            f"{{{{ PYTHON }}}} pip wheel . -w {dist} -vv",
+            "${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation",
+            f"pip wheel . -w {dist} -vv --no-deps --no-build-isolation",
         ),
+        ("$PYTHON -m pip install .", f"pip wheel . -w {dist}"),
     ]:
         assert rewrite_build_script(make_rendered(script), dist) == [expected]
 
@@ -281,12 +285,14 @@ def test_render_meta_yaml_in_process(
         """Stands in for conda_build.api"""
 
         croots: ClassVar[list[str]] = []
+        variant_files: ClassVar[list[str]] = []
         variants = 1
         fail = False
 
         @classmethod
-        def Config(cls, croot: str) -> str:
+        def Config(cls, croot: str, variant_config_files=()) -> str:
             cls.croots.append(croot)
+            cls.variant_files = list(variant_config_files)
             return croot
 
         @classmethod
@@ -389,12 +395,21 @@ def _fake_rattler_module(
             if multi:
                 raise TypeError("multi-output recipe")
 
-        def render(self) -> list:
+        def render(self, variant_config=None) -> list:
             if render_fail:
                 raise ValueError("render boom")
             return [FakeRendered() for _ in range(variants)]
 
+    class VariantConfig:
+        files: ClassVar[list[str]] = []
+
+        @classmethod
+        def from_files(cls, files: list) -> VariantConfig:
+            cls.files = list(files)
+            return cls()
+
     mod.Stage0Recipe = Stage0Recipe  # type: ignore[attr-defined]
+    mod.VariantConfig = VariantConfig  # type: ignore[attr-defined]
     return mod
 
 


### PR DESCRIPTION
Closes #216. Stacked on #228 (branched from code-cleanup; will retarget to main when #228 merges).

`whl2conda build` now handles recipes for platform-specific binary packages:

- **Non-noarch recipes convert instead of erroring**: binary conversion (`allow_impure`) is enabled automatically, and the package is written (`--output-folder`) and installed (conda-bld) into the **target platform subdir** reported by the converter — determined after the built wheel is examined, so the output move happens post-conversion. The v1 `noarch: python` hard-error is removed.
- **`--output`, `-t`/`--test`, and `--skip-existing` stay noarch-only** with a clear error: a binary package's file name depends on the python version and platform of the not-yet-built wheel.
- **`-m`/`--variant-config-files` is now a real option** (previously accept-and-ignore) passed through to both renderers — `VariantConfig.from_files` for py-rattler-build, `-m` for the rattler-build CLI, `variant_config_files` for conda-build — because real binary recipes routinely use variant-dependent expressions like `${{ stdlib('c') }}` that cannot render without one. Also added to `whl2conda test` for its recipe spec source.
- **`${{ PYTHON }}` handling**: rattler-build leaves this template unresolved in rendered v1 build scripts; the build-script rewrite now treats it (and `$PYTHON`/`{{ PYTHON }}`) as a removable interpreter prefix.
- Docs: the building guide's requirements section now describes binary recipe support, the local-toolchain caveats (including deployment-target effects), and the variant-config requirement.

## Real-world verification

Built [antlrope](https://github.com/analog-garage/antlrope)'s abi3 rattler recipe end to end — the exact recipe this feature was motivated by, which whl2conda previously refused:

```
whl2conda build antlrope/conda-recipe -m variants.yaml -c conda-forge --output-folder out --no-test
→ out/osx-arm64/antlrope-1.0.1-py312_abi3_0.conda   (7 seconds)
```

`whl2conda diff` against the rattler-build reference package shows semantic equivalence: the only errors are version skew (dev 1.0.1 vs reference 1.0.0) and the only notices are the known-benign license-format difference and the `__osx` constraint reflecting the local deployment target vs the pinned one — the documented local-toolchain caveat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)